### PR TITLE
Better bbi_init() error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 0.12.0.7104
+Version: 0.12.0.7105
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -264,8 +264,18 @@ bbi_help <- function(.cmd_args=NULL) {
 #'   **no default NONMEM version**. `FALSE` by default, and using `TRUE` is
 #'   *not* encouraged.
 #' @importFrom yaml read_yaml write_yaml
+#' @importFrom fs dir_exists
 #' @export
 bbi_init <- function(.dir, .nonmem_dir, .nonmem_version = NULL, .no_default_version = FALSE) {
+  # check that destination directory exists
+  if (!fs::dir_exists(.dir)) {
+    stop(paste(
+      glue("Cannot find {file.path(getwd(), .dir)}"),
+      "Make sure you are in the correct working directory and have passed the correct path to bbi_init(.dir)",
+      sep = "\n"
+    ), call. = FALSE)
+  }
+
   # check for files in NONMEM directory
   nm_files <- list.files(.nonmem_dir)
   if (length(nm_files) == 0) {

--- a/tests/testthat/test-bbr.R
+++ b/tests/testthat/test-bbr.R
@@ -71,6 +71,10 @@ test_that("bbi_init creates bbi.yaml", {
 
 })
 
+test_that("bbi_init errors with non-existent .dir", {
+  expect_error(bbi_init("naw", "."), regexp = "Cannot find.+naw")
+})
+
 test_that("bbi_init errors with invalid .nonmem_version", {
   # fails if don't specify anything
   expect_error(bbi_init(".", "."), regexp = "Must specify a `.nonmem_version`")


### PR DESCRIPTION
More informative error message when bbi_init(.dir) doesn't exist. Previously this was throwing an obtuse error from `processx` that made it look like it couldn't find `bbi` when in fact it couldn't find `.dir`