### PR TITLE
bbr 1.1.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.0.0.8100
+Version: 1.1.0
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",
@@ -18,7 +18,15 @@ Authors@R:
       person(given = "Sean",
              family = "Wilson",
              role = "aut",
-             email = "copernican@gmail.com"))
+             email = "copernican@gmail.com"),
+      person(given = "Samuel",
+             family = "Callisto",
+             role = "aut",
+             email = "samc@metrumrg.com"),
+      person(given = "Tim",
+             family = "Waterhouse",
+             role = "aut",
+             email = "timw@metrumrg.com"))
 Description: R package for making calls to bbi for running
     NONMEM and other models. Also manages model metadata, workflow, and
     run logs.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.0.0.8004
+Version: 1.0.0.8100
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# bbr (development)
+# bbr 1.1.0
 
 ## New features and changes
 

--- a/R/check-up-to-date.R
+++ b/R/check-up-to-date.R
@@ -23,10 +23,14 @@
 #' @param ... Arguments passed through (currently none).
 #'
 #' @return
+#' **The returned value is invisible because a message is printed** alerting the
+#' user of the specific files that have changed, if any. This facilitates
+#' calling the function for this side effect without explicitly handling the
+#' returned value.
 #'
 #' **`bbi_model`** method invisibly returns a logical vector of length 2. The
-#' first element (named `"model"`) refers to the model files mentioned above.
-#' The second element (named `"data"`) refers to the data files mentioned above.
+#' first element (named `"model"`) refers to the model files mentioned in Details.
+#' The second element (named `"data"`) refers to the data files mentioned in Details.
 #' For both elements, they will be `TRUE` if nothing has changed, `FALSE` if
 #' anything has changed. Note: _if no file exists_ at the specified path,
 #' `FALSE` will be returned because that is technically a "change." The file
@@ -43,11 +47,6 @@
 #' contains `model_has_changed` and `data_has_changed` columns. Please note:
 #' these contain the opposite boolean values (`check_up_to_date()` returns
 #' `TRUE` if up to date, `*_has_changed` returns `TRUE` if _changed_).
-#'
-#' **The returned value is invisible because a message is printed** alerting the
-#' user of the specific files that have changed, if any. This facilitates
-#' calling the function for this side effect without explicitly handling the
-#' returned value.
 #'
 #' @export
 check_up_to_date <- function(.bbi_object, ...) {

--- a/R/model-diff.R
+++ b/R/model-diff.R
@@ -27,12 +27,13 @@
 #'   * `"model"` compares the control streams
 #' * Currently only NONMEM is implemented.
 #'
-#' @return Returns a `"Diff"` object from the `diffobj` package.
+#' @return Returns a `"Diff"` object from the `diffobj` package that renders
+#'   when printed or called in the console.
 #'
 #' @param .mod The `bbi_{.model_type}_model` to compare.
 #' @param .mod2 If a `bbi_{.model_type}_model` object is passed, compare `.mod` to
-#'   `.mod2`. If `.mod2 = NULL`, the default, compare `.mod` to the model in
-#'   `.mod$based_on`. See "`based_on` details" in Details section.
+#'   `.mod2`. If `.mod2 = NULL`, the default, compare `.mod` to the model at
+#'   `get_based_on(.mod)`. See "`based_on` details" in Details section.
 #' @param .file Defaults to `"model"` which compares the default model file for
 #'   that model type. Some model types have multiple files that can be compared.
 #'   See "`.file` argument" in Details section.

--- a/R/model-summary.R
+++ b/R/model-summary.R
@@ -6,9 +6,15 @@
 
 #' Summarize model outputs
 #'
-#' Calls out to bbi and returns a named list of class `bbi_{.model_type}_summary` with model outputs and diagnostics.
+#' Calls out to `bbi` and returns a named list of class
+#' `bbi_{.model_type}_summary` with model outputs and diagnostics. If user wants
+#' to summarize multiple models, you can pass a list of
+#' `bbi_{.model_type}_model` objects to [model_summaries()], or pass a directory
+#' path to [summary_log()] to summarize all models in that directory (and, by
+#' default, all directories below it).
 #'
 #' @details
+#'
 #' **NONMEM**
 #'
 #' The returned list for a NONMEM model will contain the following top-level elements:

--- a/R/tags-diff.R
+++ b/R/tags-diff.R
@@ -7,21 +7,6 @@
 #' ignoring the `based_on` field entirely.
 #'
 #' @return
-#' **`tags_diff.bbi_model()`** invisibly returns a list with two
-#' elements, the first named `tags_added` and the second named `tags_removed`.
-#' The list is returned invisibly because, by default, a nicely formatted
-#' version of the same information is printed to the console. User can pass
-#' `.print = FALSE` to turn this off.
-#'
-#' **`tags_diff.bbi_run_log_df()`** returns a named list of lists, with one
-#' element for each row in the input tibble, with the name corresponding to the
-#' value in the `run` column for that row. Each element of the list will contain
-#' the two-element list returned from `tags_diff.bbi_model()` (described above)
-#' for the relevant model.
-#'
-#' **`add_tags_diff()`** returns the same tibble that was passed to
-#' it, but with two additional columns named `tags_added` and `tags_removed`.
-#'
 #' **In all cases:**
 #'
 #' * `tags_added` contains any tags that are on the relevant model, but _not_ on
@@ -29,6 +14,21 @@
 #'
 #' * `tags_removed` contains any tags that are on at least one of the models it
 #'   is based on, but _not_ on the relevant model.
+#'
+#' **`tags_diff.bbi_model()`** invisibly returns a list with two elements:
+#'   `tags_added` and `tags_removed`. The list is returned invisibly because, by
+#'   default, a nicely formatted version of the same information is printed to the
+#'   console. User can pass `.print = FALSE` to turn this off.
+#'
+#' **`tags_diff.bbi_run_log_df()`** returns a named list of lists, with one
+#'   element for each row in the input tibble, with the name corresponding to the
+#'   value in the `run` column for that row. Each element of the list will contain
+#'   the two-element list returned from `tags_diff.bbi_model()` (described above)
+#'   for the relevant model.
+#'
+#' **`add_tags_diff()`** returns the same tibble that was passed to it, but
+#'   it, but with two additional columns `tags_added` and `tags_removed`
+#'   appended.
 #'
 #' @param .bbi_object The object to compare. Could be a
 #'   `bbi_{.model_type}_model` object or a

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,11 +13,12 @@ navbar:
 reference:
 - title: Model management
   contents:
-  - copy_model_from
   - new_model
   - read_model
-  - reconcile_yaml
-  - check_yaml_in_sync
+  - copy_model_from
+  - model_diff
+  - tags_diff
+  - check_up_to_date
 - title: Model submission
   contents:
   - submit_model
@@ -25,19 +26,19 @@ reference:
   - print_bbi_args
 - title: Model summary
   contents:
-  - add_config
-  - apply_indices
-  - block
-  - config_log
-  - extract_from_summary
   - model_summary
   - model_summaries
-  - as_summary_list
   - param_estimates
-  - param_labels
   - run_log
   - summary_log
   - add_summary
+  - config_log
+  - add_config
+  - as_summary_list
+  - param_labels
+  - apply_indices
+  - block
+
 - title: Model object interactions
   contents:
   - add_tags
@@ -57,11 +58,12 @@ reference:
   - print_bbi
 - title: bbi configuration
   contents:
-  - bbi_current_release
-  - bbi_help
+  - use_bbi
   - bbi_init
   - bbi_version
-  - use_bbi
+  - bbi_current_release
+  - bbi_help
+
 - title: Assorted helpers
   contents:
   - check_file
@@ -81,4 +83,6 @@ reference:
   - plot_nonmem_table_df
   - plot_grd
   - plot_ext
+  - reconcile_yaml
+  - check_yaml_in_sync
   - suppressSpecificWarning

--- a/man/check_up_to_date.Rd
+++ b/man/check_up_to_date.Rd
@@ -15,9 +15,14 @@ or a \code{bbi_log_df} tibble.}
 \item{...}{Arguments passed through (currently none).}
 }
 \value{
+\strong{The returned value is invisible because a message is printed} alerting the
+user of the specific files that have changed, if any. This facilitates
+calling the function for this side effect without explicitly handling the
+returned value.
+
 \strong{\code{bbi_model}} method invisibly returns a logical vector of length 2. The
-first element (named \code{"model"}) refers to the model files mentioned above.
-The second element (named \code{"data"}) refers to the data files mentioned above.
+first element (named \code{"model"}) refers to the model files mentioned in Details.
+The second element (named \code{"data"}) refers to the data files mentioned in Details.
 For both elements, they will be \code{TRUE} if nothing has changed, \code{FALSE} if
 anything has changed. Note: \emph{if no file exists} at the specified path,
 \code{FALSE} will be returned because that is technically a "change." The file
@@ -34,11 +39,6 @@ these columns to a \code{bbi_log_df} tibble} you can use \code{\link[=add_config
 contains \code{model_has_changed} and \code{data_has_changed} columns. Please note:
 these contain the opposite boolean values (\code{check_up_to_date()} returns
 \code{TRUE} if up to date, \verb{*_has_changed} returns \code{TRUE} if \emph{changed}).
-
-\strong{The returned value is invisible because a message is printed} alerting the
-user of the specific files that have changed, if any. This facilitates
-calling the function for this side effect without explicitly handling the
-returned value.
 }
 \description{
 Functions for checking that the model outputs on disk match the md5 hashes

--- a/man/model_diff.Rd
+++ b/man/model_diff.Rd
@@ -13,8 +13,8 @@ model_diff(.mod, .mod2 = NULL, .file = "model", ..., .viewer = FALSE)
 \item{.mod}{The \verb{bbi_\{.model_type\}_model} to compare.}
 
 \item{.mod2}{If a \verb{bbi_\{.model_type\}_model} object is passed, compare \code{.mod} to
-\code{.mod2}. If \code{.mod2 = NULL}, the default, compare \code{.mod} to the model in
-\code{.mod$based_on}. See "\code{based_on} details" in Details section.}
+\code{.mod2}. If \code{.mod2 = NULL}, the default, compare \code{.mod} to the model at
+\code{get_based_on(.mod)}. See "\code{based_on} details" in Details section.}
 
 \item{.file}{Defaults to \code{"model"} which compares the default model file for
 that model type. Some model types have multiple files that can be compared.
@@ -28,7 +28,8 @@ will hold the console with \verb{Press ENTER to continue...} so it is only
 recommended for interactive use.}
 }
 \value{
-Returns a \code{"Diff"} object from the \code{diffobj} package.
+Returns a \code{"Diff"} object from the \code{diffobj} package that renders
+when printed or called in the console.
 }
 \description{
 By default, this compares a model's model file on disk to the model file of

--- a/man/model_diff_get_comp.Rd
+++ b/man/model_diff_get_comp.Rd
@@ -10,8 +10,8 @@ model_diff_get_comp(.mod, .mod2)
 \item{.mod}{The \verb{bbi_\{.model_type\}_model} to compare.}
 
 \item{.mod2}{If a \verb{bbi_\{.model_type\}_model} object is passed, compare \code{.mod} to
-\code{.mod2}. If \code{.mod2 = NULL}, the default, compare \code{.mod} to the model in
-\code{.mod$based_on}. See "\code{based_on} details" in Details section.}
+\code{.mod2}. If \code{.mod2 = NULL}, the default, compare \code{.mod} to the model at
+\code{get_based_on(.mod)}. See "\code{based_on} details" in Details section.}
 }
 \description{
 Private helper to get a valid comparison model

--- a/man/model_summary.Rd
+++ b/man/model_summary.Rd
@@ -20,7 +20,12 @@ See \code{\link[=print_bbi_args]{print_bbi_args()}} for full list of options.}
 \item{.dry_run}{show what the command would be without actually running it}
 }
 \description{
-Calls out to bbi and returns a named list of class \verb{bbi_\{.model_type\}_summary} with model outputs and diagnostics.
+Calls out to \code{bbi} and returns a named list of class
+\verb{bbi_\{.model_type\}_summary} with model outputs and diagnostics. If user wants
+to summarize multiple models, you can pass a list of
+\verb{bbi_\{.model_type\}_model} objects to \code{\link[=model_summaries]{model_summaries()}}, or pass a directory
+path to \code{\link[=summary_log]{summary_log()}} to summarize all models in that directory (and, by
+default, all directories below it).
 }
 \details{
 \strong{NONMEM}

--- a/man/tags_diff.Rd
+++ b/man/tags_diff.Rd
@@ -28,21 +28,6 @@ method.}}
 \item{.log_df}{a \code{bbi_run_log_df} tibble (the output of \code{\link[=run_log]{run_log()}})}
 }
 \value{
-\strong{\code{tags_diff.bbi_model()}} invisibly returns a list with two
-elements, the first named \code{tags_added} and the second named \code{tags_removed}.
-The list is returned invisibly because, by default, a nicely formatted
-version of the same information is printed to the console. User can pass
-\code{.print = FALSE} to turn this off.
-
-\strong{\code{tags_diff.bbi_run_log_df()}} returns a named list of lists, with one
-element for each row in the input tibble, with the name corresponding to the
-value in the \code{run} column for that row. Each element of the list will contain
-the two-element list returned from \code{tags_diff.bbi_model()} (described above)
-for the relevant model.
-
-\strong{\code{add_tags_diff()}} returns the same tibble that was passed to
-it, but with two additional columns named \code{tags_added} and \code{tags_removed}.
-
 \strong{In all cases:}
 \itemize{
 \item \code{tags_added} contains any tags that are on the relevant model, but \emph{not} on
@@ -50,6 +35,21 @@ any of the models it is based on.
 \item \code{tags_removed} contains any tags that are on at least one of the models it
 is based on, but \emph{not} on the relevant model.
 }
+
+\strong{\code{tags_diff.bbi_model()}} invisibly returns a list with two elements:
+\code{tags_added} and \code{tags_removed}. The list is returned invisibly because, by
+default, a nicely formatted version of the same information is printed to the
+console. User can pass \code{.print = FALSE} to turn this off.
+
+\strong{\code{tags_diff.bbi_run_log_df()}} returns a named list of lists, with one
+element for each row in the input tibble, with the name corresponding to the
+value in the \code{run} column for that row. Each element of the list will contain
+the two-element list returned from \code{tags_diff.bbi_model()} (described above)
+for the relevant model.
+
+\strong{\code{add_tags_diff()}} returns the same tibble that was passed to it, but
+it, but with two additional columns \code{tags_added} and \code{tags_removed}
+appended.
 }
 \description{
 By default, this compares a model's tags to the tags on any of its "parent"

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -226,6 +226,8 @@ mod2 <- mod2 %>%
   add_notes("2 compartment model more appropriate than 1 compartment")
 ```
 
+The `model_diff()` and `tags_diff()` function make it easy to compare models to their parent model. See the ["Using based_on" vignette](https://metrumresearchgroup.github.io/bbr/articles/using-based-on.html) for examples.
+
 ## Continue to iterate...
 
 Now the iteration process continues with a third model. Note that you can tell `copy_model_from()` to inherit the tags from the parent model and automatically add them to the new model.


### PR DESCRIPTION
# Release Notes
This release adds a few helper functions and makes a few small patches, but it is mostly internal refactoring in preparation for the impending `bbr_stan_alpha` branch where initial development to support Stan modeling will begin soon.

## New features and changes

* Added `tags_diff()` function for comparing the tags between different models. (#337)

* Added `model_diff()` function for comparing the model files between different models. (#342)

* Added `check_up_to_date()` function for checking whether the model file(s) and data file(s) associated with a model have changed since the model was run.  (#338)

* Added more documentation about the heuristics returned from `model_summary.bbi_nonmem_model()` (#343)

## Bug fixes

* `param_estimates()` now correctly errors when a Bayesian method is used but is _not_ the final method. (#344)

## Developer-facing changes

* Added a `bbi_model` parent class to `bbi_nonmem_model` and `bbi_nonmem_summary` objects. Many of the helpers in `get-path-from-object.R` now dispatch on this class. This had been discussed in the past but was primarily done now in preparation for beginning development for Stan modeling, which will create `bbi_stan_model` and `bbi_stan_summary` objects that will also inherit from this parent class. (#332)

