### PR TITLE
DO NOT MERGE: Experimental/submit model wait false

### DIFF
--- a/R/aaa-stan.R
+++ b/R/aaa-stan.R
@@ -5,6 +5,7 @@ STANINIT_SUFFIX <- "-init.R"
 STANARGS_SUFFIX <- "-stanargs.R"
 STAN_OUTDIR_SUFFIX <- "-output"
 STAN_MODEL_FIT_RDS <- file.path(STAN_OUTDIR_SUFFIX, "fit.RDS")
+STAN_MODEL_SMP_OUT_TXT <- file.path(STAN_OUTDIR_SUFFIX, "sampling_output.txt")
 
 STAN_MODEL_REQ_FILES <- c(
   STANMOD_SUFFIX,


### PR DESCRIPTION
This is sort of a POC demonstrating how we could use `callr` to both capture the output of cmdstanr (discussed [here](https://github.com/stan-dev/cmdstanr/issues/473)) and run it in the background for `.wait = FALSE` (discussed [here](https://github.com/stan-dev/cmdstanr/issues/424)). This may become unnecessary if those issues are resolved in `cmdstanr`.

## Concerns

Aside from any technical concerns about spawning subprocesses (which I'm sure exist) there is also the question of mechanics of the function. The simple interface shown in this initial commit _works_ but we would need to do some additional things in the subprocess:

* Save the fit model object to disk
* Build and write the `bbi_config.json` file to disk
* Compile the `.stan` file to binary
  * This one isn't _necessary_ to do inside `callr` but it's definitely ideal, especially if we want `.wait=F` to actually return quickly. Which we do.
  * Along with this, it would be cleaner code-wise to do the `stanargs` prep and maybe some other prep in the subprocess too.

**The problem** is that `callr` [doesn't pass through the environment](https://callr.r-lib.org/#using-packages), so none of our helper functions (private ones like `build_stan_config()` but also simple public helpers like `build_path_from_model()`) are _not_ available within the `callr` process. There are various workarounds for this, but the simplest of them (passing in the package namespace) I couldn't get to work because `bbr` is not installed within itself so I kept getting `package "bbr" does not exist` when I was playing with this. 

There's likely a sensible workaround, but I couldn't find one in a reasonable amount of time. I also couldn't find any guidance on using `callr` within a package, though maybe I wasn't looking in the right places.