### PR TITLE
bbi_exec() stdout and stderr to file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.1.0
+Version: 1.1.0.7000
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * There was a bug where submitting more than roughly 250 models at time via `submit_models()` (e.g. for bootstrapping) 
 would hang indefinitely. This had something to do with [a bug in processx](https://github.com/r-lib/processx/issues/286).
 It was fixed (in `bbr`) by routing the stdout and stderr to a temp file and then reading from it when necessary, instead 
-of relying on `processx` to poll the process.
+of relying on `processx` to poll the process. (#374)
 
 # bbr 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# bbr (development)
+
+## Bug fixes
+
+* There was a bug where submitting more than roughly 250 models at time via `submit_models()` (e.g. for bootstrapping) 
+would hang indefinitely. This had something to do with [a bug in processx](https://github.com/r-lib/processx/issues/286).
+It was fixed (in `bbr`) by routing the stdout and stderr to a temp file and then reading from it when necessary, instead 
+of relying on `processx` to poll the process.
+
 # bbr 1.1.0
 
 ## New features and changes

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -75,7 +75,6 @@ bbi_exec <- function(.cmd_args,
   check_bbi_exe(.bbi_exe_path)
 
   stdout_file <- tempfile("bbi_exec_out_")
-  message(paste("logging to", stdout_file))
 
   p <- processx::process$new(
     .bbi_exe_path,

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -36,7 +36,8 @@ NULL
 
 #' Execute call to bbi
 #'
-#' Private implementation function that executes a bbi call (`bbi ...`) with processx::process$new()
+#' Private implementation function that executes a bbi call (`bbi ...`) with
+#' processx::process$new()
 #'
 #' @inheritParams bbi_version
 #' @param .cmd_args A character vector of command line arguments for the execution call
@@ -44,13 +45,26 @@ NULL
 #' @param .verbose Print stdout and stderr as process runs #### NOT IMPLEMENTED?
 #' @param .wait If true, don't return until process has exited.
 #' @param ... arguments to pass to processx::process$new()
-#' @return An S3 object of class `bbi_process`
-#'         process -- The process object (see ?processx::process$new for more details on what you can do with this).
-#'         stdout -- the stdout and stderr from the process, if `.wait = TRUE`. If `.wait = FALSE` this will be NULL.
-#'         bbi -- character scalar with the execution path used for bbi.
-#'         cmd_args -- character vector of all command arguments passed to the process.
-#'         working_dir -- the directory the command was run in, passed through from .dir argument.
+#'
+#' @return An S3 object of class `bbi_process` with the following elements
+#'
+#'   * process -- The process object (see ?processx::process$new for more
+#'   details on what you can do with this).
+#'
+#'   * stdout -- the stdout and stderr from the process, if `.wait = TRUE`. If
+#'   `.wait = FALSE` this contain a message with the tempfile path where stdout
+#'   and stderr have been redirected.
+#'
+#'   * bbi -- character scalar with the execution path used for bbi.
+#'
+#'   * cmd_args -- character vector of all command arguments passed to the
+#'   process.
+#'
+#'   * working_dir -- the directory the command was run in, passed through from
+#'   .dir argument.
+#'
 #' @importFrom processx process
+#' @importFrom readr read_lines
 #' @keywords internal
 bbi_exec <- function(.cmd_args,
                      .dir = ".",
@@ -60,12 +74,15 @@ bbi_exec <- function(.cmd_args,
                      ...) {
   check_bbi_exe(.bbi_exe_path)
 
+  stdout_file <- tempfile("bbi_exec_out_")
+  message(paste("logging to", stdout_file))
+
   p <- processx::process$new(
     .bbi_exe_path,
     .cmd_args,
     ...,
     wd = .dir,
-    stdout = "|",
+    stdout = stdout_file,
     stderr = "2>&1"
   )
   if (.wait) {
@@ -96,11 +113,11 @@ bbi_exec <- function(.cmd_args,
       p$wait()
     }
     # check output status code
-    output <- p$read_all_output_lines()
+    output <- read_lines(stdout_file)
     check_status_code(p$get_exit_status(), output, .cmd_args)
 
   } else {
-    output <- "NO STDOUT BECAUSE `.wait = FALSE`"
+    output <- paste("NO STDOUT BECAUSE `.wait = FALSE`. stdout and stderr redirected to", stdout_file)
   }
   # build result object
   res <- list()

--- a/man/bbi_exec.Rd
+++ b/man/bbi_exec.Rd
@@ -27,14 +27,22 @@ bbi_exec(
 \item{...}{arguments to pass to processx::process$new()}
 }
 \value{
-An S3 object of class \code{bbi_process}
-process -- The process object (see ?processx::process$new for more details on what you can do with this).
-stdout -- the stdout and stderr from the process, if \code{.wait = TRUE}. If \code{.wait = FALSE} this will be NULL.
-bbi -- character scalar with the execution path used for bbi.
-cmd_args -- character vector of all command arguments passed to the process.
-working_dir -- the directory the command was run in, passed through from .dir argument.
+An S3 object of class \code{bbi_process} with the following elements
+\itemize{
+\item process -- The process object (see ?processx::process$new for more
+details on what you can do with this).
+\item stdout -- the stdout and stderr from the process, if \code{.wait = TRUE}. If
+\code{.wait = FALSE} this contain a message with the tempfile path where stdout
+and stderr have been redirected.
+\item bbi -- character scalar with the execution path used for bbi.
+\item cmd_args -- character vector of all command arguments passed to the
+process.
+\item working_dir -- the directory the command was run in, passed through from
+.dir argument.
+}
 }
 \description{
-Private implementation function that executes a bbi call (\verb{bbi ...}) with processx::process$new()
+Private implementation function that executes a bbi call (\verb{bbi ...}) with
+processx::process$new()
 }
 \keyword{internal}

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -8,7 +8,8 @@ Packages:
   - styler
 
 Repos:
-  - CRAN: https://cran.rstudio.com
+  - MPN: https://mpn.metworx.com/snapshots/stable/2021-02-01
+  #- CRAN: https://cran.rstudio.com
 
 Lockfile:
   Type: renv

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -8,8 +8,7 @@ Packages:
   - styler
 
 Repos:
-  - MPN: https://mpn.metworx.com/snapshots/stable/2021-02-01
-  #- CRAN: https://cran.rstudio.com
+  - CRAN: https://cran.rstudio.com
 
 Lockfile:
   Type: renv


### PR DESCRIPTION
There was a bug where submitting more than roughly 250 models at time via `submit_models()` (e.g. for bootstrapping) 
would hang indefinitely. This had something to do with [a bug in processx](https://github.com/r-lib/processx/issues/286).
It was fixed (in `bbr`) by routing the stdout and stderr to a temp file and then reading from it when necessary, instead 
of relying on `processx` to poll the process.