### PR TITLE
1.1.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.1.0.7000
+Version: 1.1.1
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,8 @@
-# bbr (development)
+# bbr 1.1.1
 
 ## Bug fixes
 
-* There was a bug where submitting more than roughly 250 models at time via `submit_models()` (e.g. for bootstrapping) 
-would hang indefinitely. This had something to do with [a bug in processx](https://github.com/r-lib/processx/issues/286).
-It was fixed (in `bbr`) by routing the stdout and stderr to a temp file and then reading from it when necessary, instead 
-of relying on `processx` to poll the process. (#374)
+* There was a bug where submitting more than roughly 250 models at time via `submit_models()` (e.g. for bootstrapping) would hang indefinitely. This had something to do with [a bug in processx](https://github.com/r-lib/processx/issues/286). It was fixed (in `bbr`) by routing the stdout and stderr to a temp file and then reading from it when necessary, instead of relying on `processx` to poll the process. (#374)
 
 # bbr 1.1.0
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# bbr <a href='https:/metrumresearchgroup.github.io/bbr'><img src='man/figures/logo.png' align="right" height="120" /></a>
+# bbr 
 
 <!-- badges: start -->
 [![Build Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/bbr/status.svg)](https://github-drone.metrumrg.com/metrumresearchgroup/bbr)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# bbr <a href='https:/metrumresearchgroup.github.io/bbr'><img src='man/figures/logo.png' align="right" height="120" /></a>
+# bbr
 
 <!-- badges: start -->
 
@@ -58,16 +58,16 @@ functionality is rolled out. A complete list can be found
 
 ### Featured Vignettes
 
-  - [Getting Started with
+-   [Getting Started with
     bbr](https://metrumresearchgroup.github.io/bbr/articles/getting-started.html)
     – Some basic scenarios for modeling with NONMEM using `bbr`,
     introducing you to its standard workflow and functionality.
-  - [Using the based\_on
+-   [Using the based\_on
     field](https://metrumresearchgroup.github.io/bbr/articles/using-based-on.html)
     – How to use the `based_on` field to track a model’s ancestry
     through the model development process, as well how to leverage
     `config_log()` to check whether older models are still up-to-date.
-  - [Creating a Model Summary
+-   [Creating a Model Summary
     Log](https://metrumresearchgroup.github.io/bbr/articles/using-summary-log.html)
     – How to use `summary_log()` to extract model diagnostics like the
     objective function value, condition number, and parameter counts.
@@ -83,8 +83,8 @@ provide isolation. To replicate this environment,
 2.  install pkgr
 
 3.  open package in an R session and run `renv::init()`
-    
-      - install `renv` \> 0.8.3-4 into default `.libPaths()` if not
+
+    -   install `renv` &gt; 0.8.3-4 into default `.libPaths()` if not
         already installed
 
 4.  run `pkgr install` in terminal within package directory


### PR DESCRIPTION
# bbr 1.1.1

## Bug fixes

* There was a bug where submitting more than roughly 250 models at time via `submit_models()` (e.g. for bootstrapping) would hang indefinitely. This had something to do with [a bug in processx](https://github.com/r-lib/processx/issues/286). It was fixed (in `bbr`) by routing the stdout and stderr to a temp file and then reading from it when necessary, instead of relying on `processx` to poll the process. (#374)
