### PR TITLE
modify_model_field helpers: unlist and type check character vector values

### DIFF
--- a/R/modify-model-field.R
+++ b/R/modify-model-field.R
@@ -30,7 +30,7 @@
 #' @param .append If `TRUE`, the default, concatenate new values with currently present values. If `FALSE`, new values will overwrite old values.
 #' @param .remove If `TRUE`, `.value` with be removed from the `.field` instead of added. `FALSE` by default. Cannot have both `.append` and `.remove` be true in the same call.
 #' @param .unique If `TRUE`, the default, de-duplicate `.mod[[.field]]` after adding new values. If `FALSE` duplicate values will be kept.
-#' @param .char_value If `TRUE`, check that `.value` is a character vector.
+#' @param .char_value If `TRUE`, check that `.value` (after unlisting) is a character vector.
 #' @export
 modify_model_field <- function(.mod, .field, .value, .append = TRUE, .remove = FALSE, .unique = TRUE, .char_value = TRUE) {
 
@@ -42,6 +42,7 @@ modify_model_field <- function(.mod, .field, .value, .append = TRUE, .remove = F
   }
 
   if (isTRUE(.char_value)) {
+    .value <- unlist(.value)
     checkmate::assert_character(.value, null.ok = TRUE)
   }
 

--- a/R/modify-model-field.R
+++ b/R/modify-model-field.R
@@ -30,14 +30,19 @@
 #' @param .append If `TRUE`, the default, concatenate new values with currently present values. If `FALSE`, new values will overwrite old values.
 #' @param .remove If `TRUE`, `.value` with be removed from the `.field` instead of added. `FALSE` by default. Cannot have both `.append` and `.remove` be true in the same call.
 #' @param .unique If `TRUE`, the default, de-duplicate `.mod[[.field]]` after adding new values. If `FALSE` duplicate values will be kept.
+#' @param .char_value If `TRUE`, check that `.value` is a character vector.
 #' @export
-modify_model_field <- function(.mod, .field, .value, .append = TRUE, .remove = FALSE, .unique = TRUE) {
+modify_model_field <- function(.mod, .field, .value, .append = TRUE, .remove = FALSE, .unique = TRUE, .char_value = TRUE) {
 
   # update .mod with any changes from yaml on disk
   check_yaml_in_sync(.mod)
 
   if (isTRUE(.append) & isTRUE(.remove)) {
     stop("modify_model_field() cannot have both `.append` and `.remove` be true in the same call.")
+  }
+
+  if (isTRUE(.char_value)) {
+    checkmate::assert_character(.value, null.ok = TRUE)
   }
 
   if (isTRUE(.append)) {
@@ -136,7 +141,8 @@ add_tags <- function(.mod, .tags) {
     .mod = .mod,
     .field = YAML_TAGS,
     .value = .tags,
-    .append = TRUE
+    .append = TRUE,
+    .char_value = TRUE
   )
 }
 
@@ -156,7 +162,8 @@ replace_all_tags <- function(.mod, .tags) {
     .mod = .mod,
     .field = YAML_TAGS,
     .value = .tags,
-    .append = FALSE
+    .append = FALSE,
+    .char_value = TRUE
   )
 }
 
@@ -175,7 +182,8 @@ remove_tags <- function(.mod, .tags) {
     .field = YAML_TAGS,
     .value = .tags,
     .append = FALSE,
-    .remove = TRUE
+    .remove = TRUE,
+    .char_value = TRUE,
   )
 }
 
@@ -213,7 +221,8 @@ add_notes <- function(.mod, .notes) {
     .mod = .mod,
     .field = YAML_NOTES,
     .value = .notes,
-    .append = TRUE
+    .append = TRUE,
+    .char_value = TRUE
   )
 }
 
@@ -233,7 +242,8 @@ replace_all_notes <- function(.mod, .notes) {
     .mod = .mod,
     .field = YAML_NOTES,
     .value = .notes,
-    .append = FALSE
+    .append = FALSE,
+    .char_value = TRUE
   )
 }
 
@@ -245,7 +255,8 @@ remove_notes <- function(.mod, .notes) {
     .field = YAML_NOTES,
     .value = .notes,
     .append = FALSE,
-    .remove = TRUE
+    .remove = TRUE,
+    .char_value = TRUE
   )
 }
 

--- a/man/modify_model_field.Rd
+++ b/man/modify_model_field.Rd
@@ -11,7 +11,8 @@ modify_model_field(
   .value,
   .append = TRUE,
   .remove = FALSE,
-  .unique = TRUE
+  .unique = TRUE,
+  .char_value = TRUE
 )
 
 replace_model_field(.mod, .field, .old_val, .new_val)
@@ -29,6 +30,8 @@ If \code{NULL} or \code{NA} is passed and \code{.append = FALSE} then \code{.fie
 \item{.remove}{If \code{TRUE}, \code{.value} with be removed from the \code{.field} instead of added. \code{FALSE} by default. Cannot have both \code{.append} and \code{.remove} be true in the same call.}
 
 \item{.unique}{If \code{TRUE}, the default, de-duplicate \code{.mod[[.field]]} after adding new values. If \code{FALSE} duplicate values will be kept.}
+
+\item{.char_value}{If \code{TRUE}, check that \code{.value} is a character vector.}
 
 \item{.old_val}{The value to be replaced. If \code{.old_val} is not present in
 \code{.mod[[.field]]}, function will warn user and return \code{.mod} unchanged.}

--- a/man/modify_model_field.Rd
+++ b/man/modify_model_field.Rd
@@ -31,7 +31,7 @@ If \code{NULL} or \code{NA} is passed and \code{.append = FALSE} then \code{.fie
 
 \item{.unique}{If \code{TRUE}, the default, de-duplicate \code{.mod[[.field]]} after adding new values. If \code{FALSE} duplicate values will be kept.}
 
-\item{.char_value}{If \code{TRUE}, check that \code{.value} is a character vector.}
+\item{.char_value}{If \code{TRUE}, check that \code{.value} (after unlisting) is a character vector.}
 
 \item{.old_val}{The value to be replaced. If \code{.old_val} is not present in
 \code{.mod[[.field]]}, function will warn user and return \code{.mod} unchanged.}

--- a/tests/testthat/test-modify-model-field.R
+++ b/tests/testthat/test-modify-model-field.R
@@ -358,10 +358,17 @@ test_that("add_tags(), add_notes() and friends check for character vector", {
   temp_mod_path <- create_temp_model()
   new_mod <- read_model(temp_mod_path)
 
+  # Accept a list value if it can be converted to a character vector.
+  new_mod <- new_mod %>%
+    add_tags(as.list(NEW_TAGS)) %>%
+    add_notes(as.list(NEW_NOTES))
+  expect_identical(new_mod[[YAML_TAGS]], c(ORIG_TAGS, NEW_TAGS))
+  expect_identical(new_mod[[YAML_NOTES]], c(NEW_NOTES))
+
+  # Otherwise passing a type other than a character vector leads to an error.
   fns <- c(add_tags, replace_all_tags, remove_tags,
            add_notes, replace_all_notes, remove_notes)
   for (fn in fns){
-    expect_error(new_mod %>% fn(list("a", "b")))
     expect_error(new_mod %>% fn(1:3))
     expect_error(new_mod %>% fn(list(1:3)))
   }

--- a/tests/testthat/test-modify-model-field.R
+++ b/tests/testthat/test-modify-model-field.R
@@ -353,3 +353,16 @@ test_that("copy_model_from() fails YAML out of sync (testing check_yaml_in_sync)
   # try to submit_model and get error
   expect_error(copy_model_from(new_mod, "foo"), regexp = "Model NOT in sync with corresponding YAML file")
 })
+
+test_that("add_tags(), add_notes() and friends check for character vector", {
+  temp_mod_path <- create_temp_model()
+  new_mod <- read_model(temp_mod_path)
+
+  fns <- c(add_tags, replace_all_tags, remove_tags,
+           add_notes, replace_all_notes, remove_notes)
+  for (fn in fns){
+    expect_error(new_mod %>% fn(list("a", "b")))
+    expect_error(new_mod %>% fn(1:3))
+    expect_error(new_mod %>% fn(list(1:3)))
+  }
+})


### PR DESCRIPTION
This PR fixes gh-387 by implementing @callistosp's suggestion: call `unlist` on the `.tags` argument of `add_tags`.  Other `modify_model_field` helpers should get the same treatment, so this change is made at the level of `modify_model_field` (through an optional parameter).  In addition, there's now a check that these values (after unlisting) are character vectors.