### PR TITLE
Fix/processx cleanup bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.1.2.7000
+Version: 1.1.2.7001
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# bbr develop
+
+## Bug fixes
+
+* Fixed a bug where submitting multiple models in a loop with `submit_model(.mode = "local", .wait = FALSE)` would cause the models to never finish because the `bbi` processes would get [killed by `processx`](https://processx.r-lib.org/reference/process.html#cleaning-up-background-processes) when the R objects were garbage collected. (#390)
+
+* `bbr` now checks for a valid configuration file _before_ calling out to `bbi` to avoid the situation where `.wait = FALSE` and the "no config file" error from `bbi` is swallowed. (#390)
+
 # bbr 1.1.2
 
 ## New features and changes

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -82,7 +82,9 @@ bbi_exec <- function(.cmd_args,
     ...,
     wd = .dir,
     stdout = stdout_file,
-    stderr = "2>&1"
+    stderr = "2>&1",
+    cleanup = .wait,
+    cleanup_tree = FALSE
   )
   if (.wait) {
     # wait for process and capture stdout and stderr

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -101,6 +101,11 @@ submit_nonmem_model <- function(.mod,
       cmd_args,
       sprintf("--config=%s", normalizePath(.config_path))
     )
+  } else {
+    default_config_path <- file.path(model_dir, "bbi.yaml")
+    if (!fs::file_exists(default_config_path)) {
+      stop(glue("Looking for default configuration file at {default_config_path}: no such file or directory"), call. = F)
+    }
   }
 
   if (.dry_run) {

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -103,7 +103,7 @@ submit_nonmem_model <- function(.mod,
     )
   } else {
     default_config_path <- file.path(model_dir, "bbi.yaml")
-    if (!fs::file_exists(default_config_path)) {
+    if (!fs::file_exists(default_config_path) && !isTRUE(.dry_run)) {
       stop(glue("Looking for default configuration file at {default_config_path}: no such file or directory"), call. = F)
     }
   }

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -5,8 +5,7 @@ context("submit_model(.dry_run=T)")
 ###################################
 
 # create fake bbi.yaml
-readr::write_file("created_by: test-submit-model", "bbi.yaml")
-on.exit({ fs::file_delete("bbi.yaml")})
+withr::local_file("bbi.yaml", writeLines("created_by: test-submit-model", "bbi.yaml"))
 
 model_dir <- ABS_MODEL_DIR
 mod_ctl_path <- file.path(model_dir, CTL_FILENAME)

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -5,7 +5,8 @@ context("submit_model(.dry_run=T)")
 ###################################
 
 # create fake bbi.yaml
-withr::local_file("bbi.yaml", writeLines("created_by: test-submit-model", "bbi.yaml"))
+readr::write_file("created_by: test-submit-model", "bbi.yaml")
+on.exit({ fs::file_delete("bbi.yaml")})
 
 model_dir <- ABS_MODEL_DIR
 mod_ctl_path <- file.path(model_dir, CTL_FILENAME)


### PR DESCRIPTION
Fixes a bug where submitting multiple models in a loop with `submit_model(.mode = "local", .wait = FALSE)` would cause the models to never finish because the `bbi` processes would get [killed by `processx`](https://processx.r-lib.org/reference/process.html#cleaning-up-background-processes) when the R objects were garbage collected.