### PR TITLE
1.1.3 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.1.2.7001
+Version: 1.1.3
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
-# bbr develop
+# bbr 1.1.3
 
 ## Bug fixes
 
 * Fixed a bug where submitting multiple models in a loop with `submit_model(.mode = "local", .wait = FALSE)` would cause the models to never finish because the `bbi` processes would get [killed by `processx`](https://processx.r-lib.org/reference/process.html#cleaning-up-background-processes) when the R objects were garbage collected. (#390)
 
-* `bbr` now checks for a valid configuration file _before_ calling out to `bbi` to avoid the situation where `.wait = FALSE` and the "no config file" error from `bbi` is swallowed. (#390)
+* `bbr` now checks for a valid configuration file _before_ calling out to `bbi` to avoid the situation where `.wait = FALSE` and the "no config file" error from `bbi` is swallowed. Note, this check is skipped if `.dry_run = TRUE`. (#390)
 
 # bbr 1.1.2
 


### PR DESCRIPTION
This is a minor bug fix release. In addition to what's below, we also updated some of the test code to use the more up-to-date testthat "fixtures" style of setup and teardown, and updated to the new bbr logo in the README. Full diff [here](https://github.com/metrumresearchgroup/bbr/compare/main...release/1.1.3).

# Release Notes

## Bug fixes

* Fixed a bug where submitting multiple models in a loop with `submit_model(.mode = "local", .wait = FALSE)` would cause the models to never finish because the `bbi` processes would get [killed by `processx`](https://processx.r-lib.org/reference/process.html#cleaning-up-background-processes) when the R objects were garbage collected. (#390)

* `bbr` now checks for a valid configuration file _before_ calling out to `bbi` to avoid the situation where `.wait = FALSE` and the "no config file" error from `bbi` is swallowed. Note, this check is skipped if `.dry_run = TRUE`. (#390)