### PR TITLE
1.1.4 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: 
     c(person(given = "Devin",
              family = "Pastoor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# bbr 1.1.4
+
+## Docs
+
+* Added "Running NONMEM in Parallel: bbr Tips and Tricks" vignette. (#407)
+
+## Bug fixes
+
+* Fixed bug where adding tags as a list instead of a character vector broke downstream functions like `collapse_to_string()` (#391)
+
 # bbr 1.1.3
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes
 
-* Fixed bug where adding tags as a list instead of a character vector broke downstream functions like `collapse_to_string()` (#391)
+* Fixed bug where adding tags as a list instead of a character vector broke downstream functions like `collapse_to_string()` (#393)
 
 # bbr 1.1.3
 


### PR DESCRIPTION
# Release Notes

## Docs

* Added "Running NONMEM in Parallel: bbr Tips and Tricks" vignette. (#407)

## Bug fixes

* Fixed bug where adding tags as a list instead of a character vector broke downstream functions like `collapse_to_string()` (#393)