### PR TITLE
print.bbi_process: avoid unintentional exec path truncation

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -19,10 +19,12 @@ NULL
 #' @importFrom cli cat_line
 #' @export
 print.bbi_process <- function(x, ..., .call_limit = 250) {
-  call_str <- glue("{x[[PROC_BBI]]} {paste(x[[PROC_CMD_ARGS]], collapse = ' ')}")
+  exec_path <- x[[PROC_BBI]]
+  call_str <- paste(x[[PROC_CMD_ARGS]], collapse = " ")
+  len_call <- nchar(exec_path) + nchar(call_str) + 1  # +1 for space
 
   # truncate model list if too long, keeping flags at the end (if any present)
-  if (nchar(call_str) > .call_limit) {
+  if (len_call > .call_limit) {
     split_call_str <- str_split(call_str, " \\-\\-", n = 2)
     mod_str <- split_call_str[[1]][1]
     flag_str <- split_call_str[[1]][2]
@@ -32,6 +34,8 @@ print.bbi_process <- function(x, ..., .call_limit = 250) {
       call_str <- paste0(call_str, " --", flag_str)
     }
   }
+  # ... and keeping the executable path at the beginning.
+  call_str <- paste(exec_path, call_str)
 
   # print call string
   cat_line("Running:", col = "green")

--- a/R/print.R
+++ b/R/print.R
@@ -26,6 +26,11 @@ print.bbi_process <- function(x, ..., .call_limit = 250) {
   call_str <- paste(x[[PROC_CMD_ARGS]], collapse = " ")
   len_call <- nchar(exec_path) + nchar(call_str) + 1  # +1 for space
 
+  trunc_marker <- " ... [truncated]"
+  # Adjust the .call_limit so that we don't "truncate" just to end up at the
+  # same length but with less information.
+  .call_limit <- .call_limit - nchar(trunc_marker)
+
   # truncate model list if too long, keeping flags at the end (if any present)
   if (len_call > .call_limit) {
     split_call_str <- str_split(call_str, " \\-\\-", n = 2)
@@ -35,7 +40,7 @@ print.bbi_process <- function(x, ..., .call_limit = 250) {
     # The length check above looked at unsplit call string. Do a second length
     # check to avoid marking an untruncated string as truncated.
     if (nchar(mod_str) > .call_limit) {
-      call_str <- paste(substr(mod_str, 1, .call_limit), "... [truncated]")
+      call_str <- paste0(substr(mod_str, 1, .call_limit), trunc_marker)
       if(!is.na(flag_str)) {
         call_str <- paste0(call_str, " --", flag_str)
       }

--- a/R/print.R
+++ b/R/print.R
@@ -32,9 +32,13 @@ print.bbi_process <- function(x, ..., .call_limit = 250) {
     mod_str <- split_call_str[[1]][1]
     flag_str <- split_call_str[[1]][2]
 
-    call_str <- paste(substr(mod_str, 1, .call_limit), "... [truncated]")
-    if(!is.na(flag_str)) {
-      call_str <- paste0(call_str, " --", flag_str)
+    # The length check above looked at unsplit call string. Do a second length
+    # check to avoid marking an untruncated string as truncated.
+    if (nchar(mod_str) > .call_limit) {
+      call_str <- paste(substr(mod_str, 1, .call_limit), "... [truncated]")
+      if(!is.na(flag_str)) {
+        call_str <- paste0(call_str, " --", flag_str)
+      }
     }
   }
   # ... and keeping the executable path at the beginning.

--- a/R/print.R
+++ b/R/print.R
@@ -13,7 +13,10 @@
 NULL
 
 #' @describeIn print_bbi Prints the call made to bbi and whether the process is still running or has finished.
-#' @param .call_limit Integer scalar for the max number of characters to print before truncating the call string.
+#' @param .call_limit Integer scalar for the max number of characters to print
+#'   before truncating the call string. This is compared with the entire length,
+#'   but only the positional arguments between the executable path and the first
+#'   long option will be truncated.
 #' @importFrom stringr str_split str_detect
 #' @importFrom fs path_norm
 #' @importFrom cli cat_line

--- a/man/print_bbi.Rd
+++ b/man/print_bbi.Rd
@@ -18,7 +18,10 @@
 
 \item{...}{Other arguments passed on to individual methods.}
 
-\item{.call_limit}{Integer scalar for the max number of characters to print before truncating the call string.}
+\item{.call_limit}{Integer scalar for the max number of characters to print
+before truncating the call string. This is compared with the entire length,
+but only the positional arguments between the executable path and the first
+long option will be truncated.}
 
 \item{.digits}{Number of significant digits to use for parameter table. Defaults to 3.}
 

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -48,7 +48,10 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
                                   "\\Q", temp_dir, "\\E", "/2\\.ctl.+")))
     expect_true(str_detect(call_str, "--overwrite --threads=4"))
 
-    # check that passing in .call_limit=30 has bbi path, NO model paths, but still has flags
+    # Check that passing in .call_limit=30 has bbi path, NO model paths, but
+    # still has flags. Note that 30 is sufficient to trigger truncation of the
+    # model arguments because "inst/model/nonmem/basic/print-test" alone is over
+    # 30 characters.
     call_str <- capture.output(print(proc[[1]], .call_limit=30))[2]
     expect_true(str_detect(call_str, fixed(read_bbi_path())))
     expect_false(str_detect(call_str, fixed(temp_dir)))

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -13,7 +13,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   test_that("print.bbi_process works with .wait = TRUE [BBR-PRNT-001]", {
     proc <- bbi_exec("--help", .wait = TRUE)
     res <- capture.output(print(proc))
-    expect_true(any(str_detect(res, PROC_HELP_STR)))
+    expect_true(any(str_detect(res, fixed(PROC_HELP_STR))))
     expect_true(any(str_detect(res, "Process finished.")))
   })
 
@@ -21,14 +21,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     proc <- bbi_exec("--help", .wait = FALSE)
     res <- capture.output(print(proc))
 
-    expect_true(any(str_detect(res, PROC_HELP_STR)))
+    expect_true(any(str_detect(res, fixed(PROC_HELP_STR))))
     expect_true(any(str_detect(res, "Not waiting for process to finish.")))
   })
 
   test_that("print.bbi_process works with dry run [BBR-PRNT-001]", {
     proc <- bbi_dry_run("--help", ".")
     res <- capture.output(print(proc))
-    expect_true(any(str_detect(res, PROC_HELP_STR)))
+    expect_true(any(str_detect(res, fixed(PROC_HELP_STR))))
     expect_true(any(str_detect(res, "DRY RUN! Process not actually run.")))
   })
 
@@ -42,14 +42,16 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
     # check that default has bbi path, at least two model paths, and flags
     call_str <- capture.output(print(proc[[1]]))[2]
-    expect_true(str_detect(call_str, read_bbi_path()))
-    expect_true(str_detect(call_str, as.character(glue("{temp_dir}/1\\.ctl.+{temp_dir}/2\\.ctl"))))
+    expect_true(str_detect(call_str, fixed(read_bbi_path())))
+    expect_true(str_detect(call_str,
+                           paste0("\\Q", temp_dir, "\\E", "/1\\.ctl.+",
+                                  "\\Q", temp_dir, "\\E", "/2\\.ctl.+")))
     expect_true(str_detect(call_str, "--overwrite --threads=4"))
 
     # check that passing in .call_limit=30 has bbi path, NO model paths, but still has flags
     call_str <- capture.output(print(proc[[1]], .call_limit=30))[2]
-    expect_true(str_detect(call_str, read_bbi_path()))
-    expect_false(str_detect(call_str, temp_dir))
+    expect_true(str_detect(call_str, fixed(read_bbi_path())))
+    expect_false(str_detect(call_str, fixed(temp_dir)))
     expect_true(str_detect(call_str, "--overwrite --threads=4"))
   })
 


### PR DESCRIPTION
`test-print.R` has two failures on my end:

```
$ Rscript -e 'devtools::test(filter = "print")'
ℹ Loading bbr
ℹ Testing bbr
✔ | F W S  OK | Context
✖ | 2      30 | testing print methods for bbi objects [7.0s]
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Failure (test-print.R:46:5): print.bbi_process(.call_limit) works [BBR-PRNT-001]
str_detect(call_str, as.character(glue("{temp_dir}/1\\.ctl.+{temp_dir}/2\\.ctl"))) is not TRUE

`actual`:   FALSE
`expected`: TRUE

Failure (test-print.R:51:5): print.bbi_process(.call_limit) works [BBR-PRNT-001]
str_detect(call_str, read_bbi_path()) is not TRUE

`actual`:   FALSE
`expected`: TRUE
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

══ Results ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 7.0 s

[ FAIL 2 | WARN 0 | SKIP 0 | PASS 30 ]
```

The last assertion is checking that the executable path and trailing long options are printed regardless of `.call_limit`, and the failure is correctly indicating that, with a long enough `bbi_exe_path`, `print.bbi_process` will truncate it.  

The second commit of this series fixes that and resolves both test failures on my end.  Working on that fix, I noticed a few other potential issues in the tests and code.  The other commits address those.
