### PR TITLE
fix: use_bbi() version message respects bbr.verbose

### DIFF
--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -336,6 +336,7 @@ bbi_version <- function(.bbi_exe_path = getOption('bbr.bbi_exe_path')){
 #' @param release_v Character scalar for version number of current release
 #' @keywords internal
 version_message <- function(local_v, release_v){
+  if (!isTRUE(getOption("bbr.verbose"))) return(invisible(NULL))
 
   if (local_v == "") {
     cat(cli::col_red("No version currently installed "))

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -2,7 +2,9 @@
 #' @description Identifies system running and pulls the relevant tarball for the
 #'   current release of bbi from GitHub, and then installs it in the directory
 #'   passed to `.dir`. If used in an interactive session, will open an
-#'   installation menu confirming the installed version.
+#'   installation menu confirming the installed version. This function will
+#'   print information about the installed version. This **printing can be
+#'   suppressed** by setting `options(bbr.verbose = FALSE)`.
 #'
 #' @details If nothing is passed to the `.path` argument, `use_bbi()` will
 #' attempt to find a valid path for installation. The following decision
@@ -33,13 +35,27 @@
 #' @importFrom glue glue_collapse
 #' @importFrom cli rule
 #'
-#' @param .path absolute path to install bbi to. See Details section for defaults, if nothing is passed.
-#' @param .version version of bbi to install. Must pass a character scalar corresponding to a tag found in `https://github.com/metrumresearchgroup/bbi/releases`
-#' @param .force If `FALSE`, the default, skips installation if requested version and local version are the same. If `TRUE` forces installation if it will be the same version.
-#' @param .quiet If `TRUE`, suppresses output printed to the console. `FALSE` by default.
+#' @param .path absolute path to install bbi to. See Details section for
+#'   defaults, if nothing is passed.
+#' @param .version version of bbi to install. Must pass a character scalar
+#'   corresponding to a tag found in
+#'   `https://github.com/metrumresearchgroup/bbi/releases`
+#' @param .force If `FALSE`, the default, skips installation if requested
+#'   version and local version are the same. If `TRUE` forces installation if it
+#'   will be the same version.
+#' @param .quiet **Deprecated.** Use `options("bbr.verbose")` instead to control
+#'   printing. Defaults to `NULL`, which reads `!getOption("bbr.verbose")`. If
+#'   `TRUE`, suppresses output printed to the console.
 #' @return character
 #' @export
-use_bbi <- function(.path = NULL, .version = "latest", .force = FALSE, .quiet = FALSE){
+use_bbi <- function(.path = NULL, .version = "latest", .force = FALSE, .quiet = NULL){
+
+  if (!is.null(.quiet)) {
+    deprecate_warn("1.5.0", "use_bbi(.quiet)", details = "Please set `options('bbr.verbose' = FALSE)` instead.")
+    checkmate::assert_logical(.quiet, len = 1)
+  } else {
+    .quiet <- !getOption("bbr.verbose")
+  }
 
   this_os <- check_os()
 
@@ -118,10 +134,7 @@ bbi_current_release <- function(){
 
 #' Private implementation function for installing bbi with interactive menu
 #' @param .body Character vector of installation commands to run with `system`
-#' @param .path path to install bbi to
-#' @param .version version of bbi to install. Must pass a character scalar corresponding to a tag found in `https://github.com/metrumresearchgroup/bbi/releases`
-#' @param .force If `FALSE`, the default, skips installation if requested version and local version are the same. If `TRUE` forces installation if it will be the same version.
-#' @param .quiet If `TRUE`, suppresses output printed to the console. `FALSE` by default.
+#' @inheritParams use_bbi
 #' @keywords internal
 install_menu <- function(.body, .path, .version, .force, .quiet){
 
@@ -140,7 +153,7 @@ install_menu <- function(.body, .path, .version, .force, .quiet){
     # like specifiying its a test environment, but a user could also want to generally suppress interactivity for
     # automatted build pipelines etc.
     if (interactive() && is.null(getOption('bbr.suppress_interactivity'))) {
-      version_message(local_v = local_v, release_v = release_v)
+      if (!isTRUE(.quiet)) version_message(local_v = local_v, release_v = release_v)
 
       print(glue::glue(cli::rule(left = cli::col_red('Do you want to install version {release_v} at {.dest_bbi_path}?'),line = 2)))
 
@@ -155,7 +168,7 @@ install_menu <- function(.body, .path, .version, .force, .quiet){
   }
 
   add_to_path_message(.dest_bbi_path)
-  version_message(local_v = local_v, release_v = release_v)
+  if (!isTRUE(.quiet)) version_message(local_v = local_v, release_v = release_v)
 }
 
 
@@ -336,8 +349,6 @@ bbi_version <- function(.bbi_exe_path = getOption('bbr.bbi_exe_path')){
 #' @param release_v Character scalar for version number of current release
 #' @keywords internal
 version_message <- function(local_v, release_v){
-  if (!isTRUE(getOption("bbr.verbose"))) return(invisible(NULL))
-
   if (local_v == "") {
     cat(cli::col_red("No version currently installed "))
   } else{

--- a/man/install_menu.Rd
+++ b/man/install_menu.Rd
@@ -9,13 +9,20 @@ install_menu(.body, .path, .version, .force, .quiet)
 \arguments{
 \item{.body}{Character vector of installation commands to run with \code{system}}
 
-\item{.path}{path to install bbi to}
+\item{.path}{absolute path to install bbi to. See Details section for
+defaults, if nothing is passed.}
 
-\item{.version}{version of bbi to install. Must pass a character scalar corresponding to a tag found in \verb{https://github.com/metrumresearchgroup/bbi/releases}}
+\item{.version}{version of bbi to install. Must pass a character scalar
+corresponding to a tag found in
+\verb{https://github.com/metrumresearchgroup/bbi/releases}}
 
-\item{.force}{If \code{FALSE}, the default, skips installation if requested version and local version are the same. If \code{TRUE} forces installation if it will be the same version.}
+\item{.force}{If \code{FALSE}, the default, skips installation if requested
+version and local version are the same. If \code{TRUE} forces installation if it
+will be the same version.}
 
-\item{.quiet}{If \code{TRUE}, suppresses output printed to the console. \code{FALSE} by default.}
+\item{.quiet}{\strong{Deprecated.} Use \code{options("bbr.verbose")} instead to control
+printing. Defaults to \code{NULL}, which reads \code{!getOption("bbr.verbose")}. If
+\code{TRUE}, suppresses output printed to the console.}
 }
 \description{
 Private implementation function for installing bbi with interactive menu

--- a/man/use_bbi.Rd
+++ b/man/use_bbi.Rd
@@ -4,16 +4,23 @@
 \alias{use_bbi}
 \title{Installs most current release of bbi}
 \usage{
-use_bbi(.path = NULL, .version = "latest", .force = FALSE, .quiet = FALSE)
+use_bbi(.path = NULL, .version = "latest", .force = FALSE, .quiet = NULL)
 }
 \arguments{
-\item{.path}{absolute path to install bbi to. See Details section for defaults, if nothing is passed.}
+\item{.path}{absolute path to install bbi to. See Details section for
+defaults, if nothing is passed.}
 
-\item{.version}{version of bbi to install. Must pass a character scalar corresponding to a tag found in \verb{https://github.com/metrumresearchgroup/bbi/releases}}
+\item{.version}{version of bbi to install. Must pass a character scalar
+corresponding to a tag found in
+\verb{https://github.com/metrumresearchgroup/bbi/releases}}
 
-\item{.force}{If \code{FALSE}, the default, skips installation if requested version and local version are the same. If \code{TRUE} forces installation if it will be the same version.}
+\item{.force}{If \code{FALSE}, the default, skips installation if requested
+version and local version are the same. If \code{TRUE} forces installation if it
+will be the same version.}
 
-\item{.quiet}{If \code{TRUE}, suppresses output printed to the console. \code{FALSE} by default.}
+\item{.quiet}{\strong{Deprecated.} Use \code{options("bbr.verbose")} instead to control
+printing. Defaults to \code{NULL}, which reads \code{!getOption("bbr.verbose")}. If
+\code{TRUE}, suppresses output printed to the console.}
 }
 \value{
 character
@@ -22,7 +29,9 @@ character
 Identifies system running and pulls the relevant tarball for the
 current release of bbi from GitHub, and then installs it in the directory
 passed to \code{.dir}. If used in an interactive session, will open an
-installation menu confirming the installed version.
+installation menu confirming the installed version. This function will
+print information about the installed version. This \strong{printing can be
+suppressed} by setting \code{options(bbr.verbose = FALSE)}.
 }
 \details{
 If nothing is passed to the \code{.path} argument, \code{use_bbi()} will

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -4,7 +4,8 @@ skip_if_not(R.version$os == "linux-gnu")
 skip_if_offline()
 
 withr::local_options(list(
-  "bbr.verbose" = FALSE
+  bbr.verbose = FALSE,
+  bbr.suppress_interactivity = TRUE
 ))
 
 tdir <- normalizePath(tempdir())
@@ -14,15 +15,10 @@ test_that("use-bbi works on linux pulling from options [BBR-UBI-001]", {
   on.exit(unlink(bbi_tmp_path))
   skip_if_over_rate_limit()
 
-  withr::with_options(c(
-    'bbr.suppress_interactivity' = TRUE,
-    'bbr.bbi_exe_path' = bbi_tmp_path
-  ),
-  {
-
-    use_bbi(.force = TRUE,
-            .quiet = TRUE)
-  })
+  withr::with_options(
+    list('bbr.bbi_exe_path' = bbi_tmp_path),
+    use_bbi(.force = TRUE)
+  )
   f_info <- file.info(bbi_tmp_path)
   expect_equal(as.character(f_info$mode), '755')
 })
@@ -32,18 +28,17 @@ test_that("use-bbi works on linux with path specified [BBR-UBI-002]", {
   on.exit(unlink(bbi_tmp_path))
   skip_if_over_rate_limit()
 
-  withr::with_options(c('bbr.suppress_interactivity' = TRUE), {
-    use_bbi(.path = bbi_tmp_path, .force = TRUE, .quiet = TRUE)
-  })
+  use_bbi(.path = bbi_tmp_path, .force = TRUE)
   f_info <- file.info(bbi_tmp_path)
   expect_equal(as.character(f_info$mode), '755')
 })
 
 
 test_that("bbi_version returns nothing with fake bbi [BBR-UBI-003]", {
-  withr::with_options(list("bbr.bbi_exe_path" = "/fake/path/bbi"), {
+  withr::with_options(
+    list("bbr.bbi_exe_path" = "/fake/path/bbi"),
     expect_equal(bbi_version(), "")
-  })
+  )
 })
 
 
@@ -54,10 +49,7 @@ test_that("use_bbi .version argument works [BBR-UBI-004]", {
   on.exit(unlink(bbi_tmp_path))
 
   test_version <- "v2.1.2"
-
-  withr::with_options(c('bbr.suppress_interactivity' = TRUE), {
-    use_bbi(bbi_tmp_path, .version = test_version, .force = TRUE, .quiet = TRUE)
-  })
+  use_bbi(bbi_tmp_path, .version = test_version, .force = TRUE)
   f_info <- file.info(bbi_tmp_path)
   expect_equal(as.character(f_info$mode), '755')
 

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -3,6 +3,10 @@ context("test-use-bbi")
 skip_if_not(R.version$os == "linux-gnu")
 skip_if_offline()
 
+withr::local_options(list(
+  "bbr.verbose" = FALSE
+))
+
 tdir <- normalizePath(tempdir())
 
 test_that("use-bbi works on linux pulling from options [BBR-UBI-001]", {


### PR DESCRIPTION
Setting `version_message()` (called by `use_bbi()`) to respect `options("bbr.verbose")` and `local_options(bbr.verbose = FALSE)` in `test-use-bbi.R` to suppress obnoxious messages that filter through test suite output.