### PR TITLE
silence recent 'R CMD check' notes about undefined variables

### DIFF
--- a/R/cov-cor.R
+++ b/R/cov-cor.R
@@ -157,7 +157,7 @@ parse_cov_cor_full_file <- function(.mod, .suffix) {
     I(.lines[(.t+1):length(.lines)]),
     col_types = readr::cols()
   ) %>%
-    select(-NAME)
+    select(-.data$NAME)
 
   df %>%
     as.matrix() %>%

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -9,3 +9,8 @@
 #' @importFrom magrittr %>%
 #' @usage lhs \%>\% rhs
 NULL
+
+if (getRversion() >= "2.15.1") {
+  # Prevent 'R CMD check' from complaining about "." argument used in pipes.
+  utils::globalVariables(".")
+}


### PR DESCRIPTION
The decision to use globalVariables() for "." is based on discussion
in magrittr's issue 29.