### PR TITLE
test: summary-log: load dplyr

### DIFF
--- a/tests/testthat/test-summary-log.R
+++ b/tests/testthat/test-summary-log.R
@@ -1,5 +1,7 @@
 context("Test creating summary logs")
 
+suppressPackageStartupMessages(library(dplyr))
+
 skip_if_not_drone_or_metworx("test-summary-log")
 
 # helper to run expectations


### PR DESCRIPTION
The unqualified `pull` calls added in d27ac23 (test: updating test
refs for eigenvalue_issues heuristic, 2021-10-20) lead to a
test-summary-log failure on my end:

    $ Rscript -e 'devtools::test(filter = "summary-log")'
    [...]
    Error in `pull(., minimization_terminated)`: could not find function
    "pull"
    Backtrace:
     1. testthat::expect_false(filter(sum_df2, run == "1001") %>%
    [...]

Rather than qualify those calls [*], follow what test-param-labels.R
does and just load dplyr.

[*] ... as well as the other unqualifed dplyr function calls in this
    file that don't error because they happen to be in NAMESPACE due
    to imports elsewhere