### PR TITLE
fix: bbi_{help,init}: restore relay of bbi output

### DIFF
--- a/R/bbr.R
+++ b/R/bbr.R
@@ -274,7 +274,7 @@ bbi_help <- function(.cmd_args=NULL) {
     .cmd_args <- c(.cmd_args, "--help")
   }
   res <- bbi_exec(.cmd_args, .wait=TRUE)
-  cat(paste(res$output, collapse = "\n"))
+  cat(paste(res[[PROC_STDOUT]], collapse = "\n"))
 }
 
 
@@ -353,5 +353,5 @@ bbi_init <- function(.dir, .nonmem_dir, .nonmem_version = NULL, .bbi_args = NULL
     write_yaml(bbi_yaml, bbi_yaml_path)
   }
 
-  cat(paste(res$output, collapse = "\n"))
+  cat(paste(res[[PROC_STDOUT]], collapse = "\n"))
 }

--- a/tests/testthat/test-bbr.R
+++ b/tests/testthat/test-bbr.R
@@ -96,3 +96,10 @@ test_that("bbi_init passes .bbi_args [BBR-BBR-008]", {
   expect_equal(bbi_yaml$threads, 36)
   expect_true(bbi_yaml$no_shk_file)
 })
+
+test_that("bbi_help captures and relays bbi output [BBR-BBR-009]", {
+  withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
+    res <- paste(capture.output(bbi_help()), collapse = "\n")
+  })
+  expect_true(stringr::str_detect(res, "bbi cli version"))
+})


### PR DESCRIPTION
When on a call today with @dpastoor working on gh-446, `bbi_help` didn't provide any output.  At first, we thought it might be Windows-specific, but it looks like a longstanding regression for all systems.

---

bbi_help() and bbi_init() are supposed to relay bbi's combined
stdout/stderr via a call to cat().  However, both functions always
produce empty output because they refer to a non-existent "output"
element.

This regression happened in dbe29fd (more debugging and cleanup,
2020-02-26), which updated bbi_exec() to return a custom list rather
than a process.  As a result, the output element name was changed from
"output" to "stdout" (indirectly through RES_PROCESS, which would
later become PROC_STDOUT).

Update bbi_help() and bbi_init() to use PROC_STDOUT.