### PR TITLE
fix: model-summary: abort if more than one lst file is found

### DIFF
--- a/R/model-summary.R
+++ b/R/model-summary.R
@@ -237,11 +237,16 @@ nonmem_summary <- function(
 
 #' Private helper function to look for .lst function in a directory
 #' @param .x The directory path to look in for the lst file
+#' @importFrom glue glue
 #' @keywords internal
 check_lst_file <- function(.x) {
   lst_file <- fs::dir_ls(.x, type = "file", glob = "*.lst")
-  if (!length(lst_file)) {
+
+  nfiles <- length(lst_file)
+  if (!nfiles) {
     stop(glue("Unable to locate `.lst` file in dir: {.x}. Check to be sure this is a NONMEM output folder, and that the run has finished successfully."))
+  } else if (nfiles > 1) {
+    stop(glue("More than one `.lst` file found in dir: {.x}"))
   }
   lst_file
 }

--- a/tests/testthat/test-model-summary.R
+++ b/tests/testthat/test-model-summary.R
@@ -170,4 +170,17 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_error(model_summary(mod2), regexp = NO_LST_ERR_MSG)
   })
 
+  test_that("model_summary() fails if multiple .lst files are present [BBR-SUM-005]", {
+    on.exit({
+      fs::dir_delete(NEW_MOD2)
+      fs::file_delete(ctl_ext(NEW_MOD2))
+      fs::file_delete(yaml_ext(NEW_MOD2))
+    })
+
+    mod2 <- MOD1 %>% copy_model_from(basename(NEW_MOD2))
+    fs::dir_copy(MOD1_PATH, NEW_MOD2)
+    fs::file_copy(file.path(NEW_MOD2, "1.lst"), file.path(NEW_MOD2, "2.lst"))
+
+    expect_error(model_summary(mod2), regexp = "More than one `\\.lst` file")
+  })
 }) # closing withr::with_options


### PR DESCRIPTION
If a model whose directory contains more than one lst is fed to
model_summary(), check_lst_file() will return all the lst files,
leading to a bbi call like this from within the model directory:

    bbi nonmem summary 1 2 --json

The output of that call isn't the expected structure of

    {
      "run_details": {...},
      "run_heuristics": {...}
      ...
    }

Instead it is

    {
      "Results": [
        {
          "run_details": {...},
          "run_heuristics": {...},
          ...
      ]
    }

which causes the downstream create_summary_object() call to fail with
an error about missing keys.

It's probably pretty rare for a user to accidentally create multiple
lst files.  However, it still seems worth guarding against given that 1) 
this case was hit into in the wild and led to a fair amount of head
scratching and 2) it's easy to do.

---

cc @timwaterhouse 