### PR TITLE
pkgdown: include param_estimates_compare in index

### DIFF
--- a/R/helpers-for-tests.R
+++ b/R/helpers-for-tests.R
@@ -42,6 +42,7 @@ skip_if_not_drone_or_metworx <- function(.test_name) {
 #' skipped.
 #'
 #' @param v a package version or a string that can be converted to one
+#' @keywords internal
 skip_if_old_bbi <- function(v) {
     v_bbi <- package_version(bbi_version(), strict = FALSE)
     if (!is.na(v_bbi)) {

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -33,6 +33,7 @@ reference:
   - model_summaries
   - param_estimates
   - param_estimates_batch
+  - param_estimates_compare
   - nm_file
   - nm_join
   - nm_tables

--- a/man/skip_if_old_bbi.Rd
+++ b/man/skip_if_old_bbi.Rd
@@ -13,3 +13,4 @@ skip_if_old_bbi(v)
 If the version can't be parsed by \code{\link[=package_version]{package_version()}}, the test is never
 skipped.
 }
+\keyword{internal}


### PR DESCRIPTION
Generating the docs for the 1.3.0 release, I noticed a warning message about `param_estimates_compare` missing from the index.  This adds that function to the index and silences another message about an internal function.

I should have taken a look before the release, but, this is the only change on top of develop, so I'll regenerate the 1.3.0 docs once this is merged in.