### PR TITLE
Validation: creating bbr-requirements.yaml and modifying bbr-stories.yaml

### DIFF
--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -1,0 +1,1060 @@
+BBR-R001:
+  description: check_status_code works as expected
+  tests:
+  - BBR-BBR-001
+BBR-R002:
+  description: bbi_dry_run() correctly returns object
+  tests:
+  - BBR-BBR-002
+BBR-R003:
+  description: check_bbi_exe() correctly errors or finds paths
+  tests:
+  - BBR-BBR-003
+BBR-R004:
+  description: check_bbi_exe() errors on too low version
+  tests:
+  - BBR-BBR-004
+BBR-R005:
+  description: bbi_init creates bbi.yaml
+  tests:
+  - BBR-BBR-005
+BBR-R006:
+  description: bbi_init errors with non-existent .dir
+  tests:
+  - BBR-BBR-006
+BBR-R007:
+  description: bbi_init errors with invalid .nonmem_version
+  tests:
+  - BBR-BBR-007
+BBR-R008:
+  description: bbi_init passes .bbi_args
+  tests:
+  - BBR-BBR-008
+BBR-R009:
+  description: bbi_help captures and relays bbi output
+  tests:
+  - BBR-BBR-009
+CGLG-R001:
+  description: config_log() returns NULL and warns when no YAML found
+  tests:
+  - BBR-CGLG-001
+CGLG-R002:
+  description: config_log() works correctly with nested dirs
+  tests:
+  - BBR-CGLG-002
+CGLG-R003:
+  description: config_log(.recurse = FALSE) works
+  tests:
+  - BBR-CGLG-003
+CGLG-R004:
+  description: config_log() reflects model mismatch
+  tests:
+  - BBR-CGLG-004
+CGLG-R005:
+  description: config_log() reflects data mismatch
+  tests:
+  - BBR-CGLG-005
+CGLG-R006:
+  description: config_log() includes bbi version
+  tests:
+  - BBR-CGLG-006
+CGLG-R007:
+  description: config_log() includes NONMEM version
+  tests:
+  - BBR-CGLG-007
+CGLG-R008:
+  description: add_config() works correctly
+  tests:
+  - BBR-CGLG-008
+CGLG-R009:
+  description: add_config() has correct columns
+  tests:
+  - BBR-CGLG-009
+CGLG-R010:
+  description: add_config() works correctly with missing json
+  tests:
+  - BBR-CGLG-010
+CGLG-R011:
+  description: config_log() works with missing output dirs
+  tests:
+  - BBR-CGLG-011
+CGLG-R012:
+  description: config_log() works with no json found
+  tests:
+  - BBR-CGLG-012
+CGLG-R013:
+  description: add_config() works no json found
+  tests:
+  - BBR-CGLG-013
+CGLG-R014:
+  description: config_log() works with filtering parameter
+  tests:
+  - BBR-CGLG-014
+CLM-R001:
+  description: delete_models() works for models created by test_threads by default
+  tests:
+  - BBR-CLM-001
+CLM-R002:
+  description: delete_models() with .tags
+  tests:
+  - BBR-CLM-002
+CLM-R003:
+  description: delete_models() with models with multiple tags
+  tests:
+  - BBR-CLM-003
+CLM-R004:
+  description: delete_models() with .tags=NULL
+  tests:
+  - BBR-CLM-004
+CMF-R001:
+  description: copy_from_model creates accurate copy
+  tests:
+  - BBR-CMF-001
+CMF-R002:
+  description: copy_from_model options work
+  tests:
+  - BBR-CMF-002
+CMF-R003:
+  description: copy_from_model.bbi_nonmem_model works with numeric input
+  tests:
+  - BBR-CMF-003
+CMF-R004:
+  description: copy_from_model .overwrite=TRUE works
+  tests:
+  - BBR-CMF-004
+CMF-R005:
+  description: copy_from_model .overwrite=FALSE works
+  tests:
+  - BBR-CMF-005
+CMF-R006:
+  description: copy_model_from() supports `.new_model` containing a period
+  tests:
+  - BBR-CMF-006
+CMF-R007:
+  description: copy_model_from(.new_model=NULL)
+  tests:
+  - BBR-CMF-007
+CMH-R001:
+  description: update_model_id() works with run number
+  tests:
+  - BBR-CMH-001
+CMH-R002:
+  description: update_model_id() works with character ID
+  tests:
+  - BBR-CMH-002
+CMH-R003:
+  description: update_model_id() is case-sensitive
+  tests:
+  - BBR-CMH-003
+CMH-R004:
+  description: update_model_id() .suffixes works
+  tests:
+  - BBR-CMH-004
+CMH-R005:
+  description: update_model_id() .additional_suffixes works
+  tests:
+  - BBR-CMH-005
+CMH-R006:
+  description: update_model_id() errors with no based_on
+  tests:
+  - BBR-CMH-006
+CRT-R001:
+  description: check_run_times() works with one model
+  tests:
+  - BBR-CRT-001
+CRT-R002:
+  description: check_run_times() works with multiple models
+  tests:
+  - BBR-CRT-002
+CRT-R003:
+  description: check_run_times() .return_times arg
+  tests:
+  - BBR-CRT-003
+CRT-R004:
+  description: check_run_times() waits for models to complete
+  tests:
+  - BBR-CRT-004
+CRT-R005:
+  description: check_run_times() works with a bbi_nonmem_summary object
+  tests:
+  - BBR-CRT-005
+CRT-R006:
+  description: check_run_times() works with a bbi_summary_list object
+  tests:
+  - BBR-CRT-006
+CTS-R001:
+  description: collapse_to_string() works correctly
+  tests:
+  - BBR-CTS-001
+CTS-R002:
+  description: collapse_to_string() warns correctly
+  tests:
+  - BBR-CTS-002
+CTS-R003:
+  description: collapse_to_string() errors correctly
+  tests:
+  - BBR-CTS-003
+CTS-R004:
+  description: collapse_to_string() renders dput correctly
+  tests:
+  - BBR-CTS-004
+CTS-R005:
+  description: collapse_to_string() renders dput for tibbles
+  tests:
+  - BBR-CTS-005
+CTS-R006:
+  description: add_tags() converts lists upstream of collapse_to_string()
+  tests:
+  - BBR-CTS-006
+CUTD-R001:
+  description: check_up_to_date.bbi_nonmem_model() happy path
+  tests:
+  - BBR-CUTD-001
+CUTD-R002:
+  description: check_up_to_date.bbi_nonmem_model() with mismatched model
+  tests:
+  - BBR-CUTD-002
+CUTD-R003:
+  description: check_up_to_date.bbi_nonmem_model() with mismatched data
+  tests:
+  - BBR-CUTD-003
+CUTD-R004:
+  description: check_up_to_date.bbi_nonmem_model() with missing data
+  tests:
+  - BBR-CUTD-004
+CUTD-R005:
+  description: check_up_to_date.bbi_nonmem_model() with mismatched both
+  tests:
+  - BBR-CUTD-005
+CUTD-R006:
+  description: check_up_to_date.bbi_nonmem_summary() with mismatched model
+  tests:
+  - BBR-CUTD-006
+CUTD-R007:
+  description: check_up_to_date.bbi_log_df() works as expected
+  tests:
+  - BBR-CUTD-007
+CVCR-R001:
+  description: cov_cor() works basic model
+  tests:
+  - BBR-CVCR-001
+CVCR-R002:
+  description: cov_cor() works with two estimation methods
+  tests:
+  - BBR-CVCR-002
+CVCR-R003:
+  description: cov_cor() warns with correlations over threshold
+  tests:
+  - BBR-CVCR-003
+CVCR-R004:
+  description: cov_cor() errors if no .cov file
+  tests:
+  - BBR-CVCR-004
+CVCR-R005:
+  description: check_cor_threshold() works correctly
+  tests:
+  - BBR-CVCR-005
+GBO-R001:
+  description: get_based_on works happy path model object
+  tests:
+  - BBR-GBO-001
+GBO-R002:
+  description: get_based_on works happy path character
+  tests:
+  - BBR-GBO-002
+GBO-R003:
+  description: get_based_on.character() fails with vector
+  tests:
+  - BBR-GBO-003
+GBO-R004:
+  description: get_based_on works happy path run_log tibble
+  tests:
+  - BBR-GBO-004
+GBO-R005:
+  description: get_based_on constructs ancestry manually
+  tests:
+  - BBR-GBO-005
+GBO-R006:
+  description: get_based_on .check_exists=TRUE errors if model is gone
+  tests:
+  - BBR-GBO-006
+GBO-R007:
+  description: get_based_on() behaves correctly on missing keys
+  tests:
+  - BBR-GBO-007
+GBO-R008:
+  description: get_model_ancestry works happy path model object
+  tests:
+  - BBR-GBO-008
+GBO-R009:
+  description: get_model_ancestry works happy path character
+  tests:
+  - BBR-GBO-009
+GBO-R010:
+  description: get_model_ancestry.character() fails with vector
+  tests:
+  - BBR-GBO-010
+GBO-R011:
+  description: get_model_ancestry works happy path run_log tibble
+  tests:
+  - BBR-GBO-011
+GBO-R012:
+  description: get_model_ancestry errors if model is gone
+  tests:
+  - BBR-GBO-012
+GBO-R013:
+  description: get_model_ancestry works on run_log tibble with more complicated ancestry
+  tests:
+  - BBR-GBO-013
+GPFO-R001:
+  description: get_model_path() builds the right path
+  tests:
+  - BBR-GPFO-001
+GPFO-R002:
+  description: get_output_dir() builds the right path
+  tests:
+  - BBR-GPFO-002
+GPFO-R003:
+  description: get_yaml_path() builds the right path
+  tests:
+  - BBR-GPFO-003
+GPFO-R004:
+  description: get_model_path() builds the right path from summary object
+  tests:
+  - BBR-GPFO-004
+GPFO-R005:
+  description: get_output_dir() builds the right path from summary object
+  tests:
+  - BBR-GPFO-005
+GPFO-R006:
+  description: get_yaml_path() builds the right path from summary object
+  tests:
+  - BBR-GPFO-006
+GPFO-R007:
+  description: get_model_path() works with bbi_*_log_df
+  tests:
+  - BBR-GPFO-007
+GPFO-R008:
+  description: get_output_dir() works with bbi_*_log_df
+  tests:
+  - BBR-GPFO-008
+GPFO-R009:
+  description: get_yaml_path() works with bbi_*_log_df
+  tests:
+  - BBR-GPFO-009
+GPFO-R010:
+  description: get_model_path() finds .mod path
+  tests:
+  - BBR-GPFO-010
+GPFO-R011:
+  description: get_model_path() errors with both .ctl and .mod paths
+  tests:
+  - BBR-GPFO-011
+GPFO-R012:
+  description: get_model_path() works no paths found
+  tests:
+  - BBR-GPFO-012
+GPFO-R013:
+  description: get_model_id parses ../../inst/model/nonmem/basic/1
+  tests:
+  - BBR-GPFO-013
+GPFO-R014:
+  description: get_model_id parses model object
+  tests:
+  - BBR-GPFO-014
+GPFO-R015:
+  description: get_model_id parses summary object
+  tests:
+  - BBR-GPFO-015
+GPFO-R016:
+  description: get_data_path parses model object
+  tests:
+  - BBR-GPFO-016
+GPFO-R017:
+  description: get_data_path parses summary object
+  tests:
+  - BBR-GPFO-017
+GPFO-R018:
+  description: build_path_from_model returns correct
+  tests:
+  - BBR-GPFO-018
+GPFO-R019:
+  description: build_path_from_model returns correct
+  tests:
+  - BBR-GPFO-019
+GPFO-R020:
+  description: build_path_from_model works with period in extension
+  tests:
+  - BBR-GPFO-020
+GPFO-R021:
+  description: is_valid_nonmem_extension() works
+  tests:
+  - BBR-GPFO-021
+GPFO-R022:
+  description: is_valid_yaml_extension() works
+  tests:
+  - BBR-GPFO-022
+GPFO-R023:
+  description: ctl_ext parses ../../inst/model/nonmem/basic/1
+  tests:
+  - BBR-GPFO-023
+GPFO-R024:
+  description: mod_ext parses ../../inst/model/nonmem/basic/1
+  tests:
+  - BBR-GPFO-024
+GPFO-R025:
+  description: yaml_ext parses ../../inst/model/nonmem/basic/1
+  tests:
+  - BBR-GPFO-025
+GPFO-R026:
+  description: get_config_path()
+  tests:
+  - BBR-GPFO-026
+MDF-R001:
+  description: model_diff.bbi_nonmem_model happy path based_on
+  tests:
+  - BBR-MDF-001
+MDF-R002:
+  description: model_diff.bbi_nonmem_model happy path .mod2 arg
+  tests:
+  - BBR-MDF-002
+MDF-R003:
+  description: model_diff.bbi_nonmem_model errors with no based_on
+  tests:
+  - BBR-MDF-003
+MDF-R004:
+  description: model_diff.bbi_nonmem_model errors with multiple based_on
+  tests:
+  - BBR-MDF-004
+MMF-R001:
+  description: modify_model_field() works correctly
+  tests:
+  - BBR-MMF-001
+MMF-R002:
+  description: modify_model_field() de-duplication works
+  tests:
+  - BBR-MMF-002
+MMF-R003:
+  description: modify_model_field() errors with .append=T and .remove=T
+  tests:
+  - BBR-MMF-003
+MMF-R004:
+  description: add_tags() and replace_all_tags() work correctly
+  tests:
+  - BBR-MMF-004
+MMF-R005:
+  description: replace_model_field() works correctly
+  tests:
+  - BBR-MMF-005
+MMF-R006:
+  description: add_notes() and replace_all_notes() work correctly
+  tests:
+  - BBR-MMF-006
+MMF-R007:
+  description: remove_notes() works correctly
+  tests:
+  - BBR-MMF-007
+MMF-R008:
+  description: replace_description() works correctly
+  tests:
+  - BBR-MMF-008
+MMF-R009:
+  description: replace_description() can use NULL
+  tests:
+  - BBR-MMF-009
+MMF-R010:
+  description: replace_description() can use NA
+  tests:
+  - BBR-MMF-010
+MMF-R011:
+  description: add_bbi_args() and replace_all_bbi_args() work correctly
+  tests:
+  - BBR-MMF-011
+MMF-R012:
+  description: add_tags etc. can be chained
+  tests:
+  - BBR-MMF-012
+MMF-R013:
+  description: add_based_on() and replace_all_based_on() work correctly
+  tests:
+  - BBR-MMF-013
+MMF-R014:
+  description: reconcile_yaml() pulls in new tags
+  tests:
+  - BBR-MMF-014
+MMF-R015:
+  description: check_yaml_in_sync() passes when nothing has changed
+  tests:
+  - BBR-MMF-015
+MMF-R016:
+  description: check_yaml_in_sync() fails when YAML has changed and passes after reconciled
+  tests:
+  - BBR-MMF-016
+MMF-R017:
+  description: add_tags fails if it wasn't re-assigned previously (testing check_yaml_in_sync)
+  tests:
+  - BBR-MMF-017
+MMF-R018:
+  description: submit_model() fails YAML out of sync (testing check_yaml_in_sync)
+  tests:
+  - BBR-MMF-018
+MMF-R019:
+  description: model_summary() fails YAML out of sync (testing check_yaml_in_sync)
+  tests:
+  - BBR-MMF-019
+MMF-R020:
+  description: copy_model_from() fails YAML out of sync (testing check_yaml_in_sync)
+  tests:
+  - BBR-MMF-020
+MMF-R021:
+  description: add_tags(), add_notes() and friends check for character vector
+  tests:
+  - BBR-MMF-021
+MMF-R022:
+  description: remove_tags() works correctly
+  tests:
+  - BBR-MMF-022
+NMF-R001:
+  description: nm_file() works
+  tests:
+  - BBR-NMF-001
+NMF-R003:
+  description: nm_grd() works
+  tests:
+  - BBR-NMF-003
+NMF-R004:
+  description: nm_file() with multiple tables
+  tests:
+  - BBR-NMF-004
+NMF-R005:
+  description: nm_data() works
+  tests:
+  - BBR-NMF-005
+NMF-R006:
+  description: nm_tab() works
+  tests:
+  - BBR-NMF-006
+NMF-R007:
+  description: nm_par_tab() works
+  tests:
+  - BBR-NMF-007
+NMJ-R001:
+  description: nm_join() works correctly
+  tests:
+  - BBR-NMJ-001
+NMJ-R002:
+  description: nm_join(.superset) works correctly
+  tests:
+  - BBR-NMJ-002
+NMJ-R003:
+  description: nm_join(.files) works correctly FIRSTONLY
+  tests:
+  - BBR-NMJ-003
+NMJ-R004:
+  description: 'nm_join() works correctly: duplicate cols'
+  tests:
+  - BBR-NMJ-004
+NMJ-R005:
+  description: nm_join(.join_col) works correctly
+  tests:
+  - BBR-NMJ-005
+NMJ-R006:
+  description: nm_join() warns on skipping table with wrong number of rows
+  tests:
+  - BBR-NMJ-006
+NMT-R001:
+  description: nm_tables() works
+  tests:
+  - BBR-NMT-001
+NMT-R002:
+  description: nm_tables() naming works correctly
+  tests:
+  - BBR-NMT-002
+NMT-R003:
+  description: nm_table_files()
+  tests:
+  - BBR-NMT-003
+NWMD-R001:
+  description: read_model() returns expected object
+  tests:
+  - BBR-NWMD-001
+NWMD-R002:
+  description: read_model() returns expected object from no ext specified
+  tests:
+  - BBR-NWMD-002
+NWMD-R003:
+  description: read_model() can read a model whose path has a period
+  tests:
+  - BBR-NWMD-003
+NWMD-R004:
+  description: new_model() creates new YAML file
+  tests:
+  - BBR-NWMD-004
+NWMD-R005:
+  description: new_model() throws an error if the model file does not exist
+  tests:
+  - BBR-NWMD-005
+NWMD-R006:
+  description: compare read_model() and new_model() objects
+  tests:
+  - BBR-NWMD-006
+NWMD-R007:
+  description: new_model() .overwrite arg works
+  tests:
+  - BBR-NWMD-007
+NWMD-R008:
+  description: new_model() .based_on arg works
+  tests:
+  - BBR-NWMD-008
+NWMD-R009:
+  description: new_model() .based_on arg errors on fake model
+  tests:
+  - BBR-NWMD-009
+NWMD-R010:
+  description: new_model() supports `.path` containing a period
+  tests:
+  - BBR-NWMD-010
+PEST-R001:
+  description: param_estimates.bbi_model_summary gets expected table
+  tests:
+  - BBR-PEST-001
+PEST-R002:
+  description: param_estimates correctly errors on Bayesian model
+  tests:
+  - BBR-PEST-002
+PEST-R003:
+  description: param_estimates correctly errors on
+  tests:
+  - BBR-PEST-003
+PEST-R004:
+  description: param_estimates correctly warns on mixture model
+  tests:
+  - BBR-PEST-004
+PEST-R005:
+  description: param_estimates_batch produces expected output
+  tests:
+  - BBR-PEST-005
+PEST-R006:
+  description: param_estimates_batch() works with varying number of param estimates
+  tests:
+  - BBR-PEST-006
+PEST-R007:
+  description: param_estimates_batch() works if an .ext file detected is empty
+  tests:
+  - BBR-PEST-007
+PEST-R008:
+  description: param_estimates_batch() works if the termination line is missing in
+    an .ext file
+  tests:
+  - BBR-PEST-008
+PEST-R009:
+  description: param_estimates_compare() works on
+  tests:
+  - BBR-PEST-009
+PEST-R010:
+  description: param_estimates_compare() works .compare_cols argument
+  tests:
+  - BBR-PEST-010
+PEST-R011:
+  description: param_estimates_compare() works
+  tests:
+  - BBR-PEST-011
+PEST-R012:
+  description: param_estimates_compare() errors with different models
+  tests:
+  - BBR-PEST-012
+PLB-R001:
+  description: build_matrix_indices() parses correctly ref
+  tests:
+  - BBR-PLB-001
+PLB-R002:
+  description: block() parses correctly 5
+  tests:
+  - BBR-PLB-002
+PLB-R003:
+  description: param_labels.character errors on vector
+  tests:
+  - BBR-PLB-003
+PLB-R004:
+  description: parse_param_comment() called internally PEX
+  tests:
+  - BBR-PLB-004
+PLB-R005:
+  description: param_labels.character() %>% apply_indices() matches tidynm reference
+  tests:
+  - BBR-PLB-005
+PLB-R006:
+  description: param_labels.bbi_nonmem_model() %>% apply_indices() matches tidynm
+    reference
+  tests:
+  - BBR-PLB-006
+PRNT-R001:
+  description: print.bbi_process
+  tests:
+  - BBR-PRNT-001
+PRNT-R002:
+  description: print.bbi_nonmem_model
+  tests:
+  - BBR-PRNT-002
+PRNT-R003:
+  description: print.bbi_nonmem_summary
+  tests:
+  - BBR-PRNT-003
+RBP-R001:
+  description: read_bbi_path() looks for environment variable
+  tests:
+  - BBR-RBP-001
+RNLG-R001:
+  description: run_log() errors with malformed YAML
+  tests:
+  - BBR-RNLG-001
+RNLG-R002:
+  description: run_log returns NULL and warns when no YAML found
+  tests:
+  - BBR-RNLG-002
+RNLG-R003:
+  description: run_log matches reference
+  tests:
+  - BBR-RNLG-003
+RNLG-R004:
+  description: run_log() works correctly with nested dirs
+  tests:
+  - BBR-RNLG-004
+RNLG-R005:
+  description: run_log() works with filtering parameter
+  tests:
+  - BBR-RNLG-005
+ROT-R001:
+  description: check_file returns correctly
+  tests:
+  - BBR-ROT-001
+ROT-R002:
+  description: check_file head=
+  tests:
+  - BBR-ROT-002
+ROT-R003:
+  description: tail_output()
+  tests:
+  - BBR-ROT-003
+ROT-R004:
+  description: tail_lst()
+  tests:
+  - BBR-ROT-004
+ROT-R005:
+  description: check_output_dir()
+  tests:
+  - BBR-ROT-005
+ROT-R006:
+  description: check_output_dir()
+  tests:
+  - BBR-ROT-006
+ROT-R007:
+  description: check_nonmem_table_output() output matches ref df
+  tests:
+  - BBR-ROT-007
+ROT-R008:
+  description: check_nonmem_table_output(.x_floor=0) works
+  tests:
+  - BBR-ROT-008
+ROT-R009:
+  description: check_ext()
+  tests:
+  - BBR-ROT-009
+ROT-R010:
+  description: check_ext() summary object
+  tests:
+  - BBR-ROT-010
+ROT-R011:
+  description: check_ext()
+  tests:
+  - BBR-ROT-011
+ROT-R012:
+  description: check_grd()
+  tests:
+  - BBR-ROT-012
+ROT-R013:
+  description: check_grd() summary object
+  tests:
+  - BBR-ROT-013
+ROT-R014:
+  description: check_grd()
+  tests:
+  - BBR-ROT-014
+ROT-R015:
+  description: check_grd()
+  tests:
+  - BBR-ROT-015
+SBMT-R001:
+  description: submit_model(.dry_run=T) returns correct command string
+  tests:
+  - BBR-SBMT-001
+SBMT-R002:
+  description: submit_model(.dry_run=T) with bbi_nonmem_model object parses correctly
+  tests:
+  - BBR-SBMT-002
+SBMT-R003:
+  description: submit_model() creates correct call for non-NULL .config_path
+  tests:
+  - BBR-SBMT-003
+SBMT-R004:
+  description: submit_model() throws an error if passed `output_dir` bbi arg
+  tests:
+  - BBR-SBMT-004
+SBMT-R005:
+  description: submit_model(.mode) inherits option
+  tests:
+  - BBR-SBMT-005
+SBMT-R006:
+  description: submit_model(.mode) errors when NULL
+  tests:
+  - BBR-SBMT-006
+SBMT-R007:
+  description: submit_model(.mode) errors when invalid
+  tests:
+  - BBR-SBMT-007
+SBMT-R008:
+  description: submit_models(.dry_run=T) with list input simple
+  tests:
+  - BBR-SBMT-008
+SBMT-R010:
+  description: submit_models(.dry_run=T) with list input, 2 arg sets
+  tests:
+  - BBR-SBMT-010
+SBMT-R011:
+  description: submit_models() works for models in different directories
+  tests:
+  - BBR-SBMT-011
+SBMT-R012:
+  description: submit_models(.dry_run=T) errors with bad input
+  tests:
+  - BBR-SBMT-012
+SBMT-R013:
+  description: submit_models() works with non-NULL .config_path
+  tests:
+  - BBR-SBMT-013
+SBMT-R014:
+  description: submit_models() works if .bbi_args is empty
+  tests:
+  - BBR-SBMT-014
+SBMT-R015:
+  description: submit_models(.mode) inherits option
+  tests:
+  - BBR-SBMT-015
+SMLG-R001:
+  description: summary_log() returns NULL and warns when no YAML found
+  tests:
+  - BBR-SMLG-001
+SMLG-R002:
+  description: summary_log() works correctly with nested dirs
+  tests:
+  - BBR-SMLG-002
+SMLG-R003:
+  description: summary_log(.recurse = FALSE) works
+  tests:
+  - BBR-SMLG-003
+SMLG-R004:
+  description: add_summary() works correctly
+  tests:
+  - BBR-SMLG-004
+SMLG-R005:
+  description: add_summary() has correct columns
+  tests:
+  - BBR-SMLG-005
+SMLG-R006:
+  description: summary_log() parses heuristics correctly
+  tests:
+  - BBR-SMLG-006
+SMLG-R007:
+  description: summary_log() parses more complex flags and stats
+  tests:
+  - BBR-SMLG-007
+SMLG-R008:
+  description: summary_log works some failed summaries
+  tests:
+  - BBR-SMLG-008
+SMLG-R009:
+  description: summary_log works all failed summaries
+  tests:
+  - BBR-SMLG-009
+SMLG-R010:
+  description: add_summary works all failed summaries
+  tests:
+  - BBR-SMLG-010
+SMLG-R011:
+  description: summary_log() works with filtering parameter
+  tests:
+  - BBR-SMLG-011
+SUM-R001:
+  description: model_summary.bbi_nonmem_model produces expected output
+  tests:
+  - BBR-SUM-001
+SUM-R002:
+  description: model_summary() works with custom .ext file
+  tests:
+  - BBR-SUM-002
+SUM-R003:
+  description: model_summary() works with no .
+  tests:
+  - BBR-SUM-003
+SUM-R004:
+  description: model_summary() fails predictably if it can't find some parts (i.e.
+    model isn't finished)
+  tests:
+  - BBR-SUM-004
+SUM-R005:
+  description: model_summary() fails
+  tests:
+  - BBR-SUM-005
+SUM-R006:
+  description: model_summaries.list produces expected output
+  tests:
+  - BBR-SUM-006
+SUM-R007:
+  description: model_summaries.list fails with bad list
+  tests:
+  - BBR-SUM-007
+SUM-R008:
+  description: model_summaries.bbi_run_log_df produces expected output
+  tests:
+  - BBR-SUM-008
+SUM-R009:
+  description: as_summary_list.bbi_summary_log_df works
+  tests:
+  - BBR-SUM-009
+TDF-R001:
+  description: tags_diff.bbi_model default happy path works
+  tests:
+  - BBR-TDF-001
+TDF-R002:
+  description: tags_diff.bbi_model print works
+  tests:
+  - BBR-TDF-002
+TDF-R003:
+  description: tags_diff.bbi_model .mod2 works
+  tests:
+  - BBR-TDF-003
+TDF-R004:
+  description: tags_diff.bbi_run_log_df works
+  tests:
+  - BBR-TDF-004
+TSTT-R001:
+  description: test_threads(.dry_run=T) creates copy models
+  tests:
+  - BBR-TSTT-001
+TSTT-R002:
+  description: test_threads(.dry_run=T) correctly changes maxeval/niter
+  tests:
+  - BBR-TSTT-002
+TSTT-R003:
+  description: test_threads(.dry_run=T) threads are set correctly
+  tests:
+  - BBR-TSTT-003
+TSTT-R004:
+  description: test_threads(.dry_run=T) correctly errors out if no maxeval, or both
+    maxeval and niter are provided
+  tests:
+  - BBR-TSTT-004
+TSTT-R005:
+  description: check_run_times() returns NA for dry runs
+  tests:
+  - BBR-TSTT-005
+UBI-R001:
+  description: use-bbi works on linux pulling from options
+  tests:
+  - BBR-UBI-001
+UBI-R002:
+  description: use-bbi works on linux with path specified
+  tests:
+  - BBR-UBI-002
+UBI-R003:
+  description: bbi_version returns nothing with fake bbi
+  tests:
+  - BBR-UBI-003
+UBI-R004:
+  description: use_bbi .version argument works
+  tests:
+  - BBR-UBI-004
+UBI-R005:
+  description: use-bbi and bbi_version handle path with spaces
+  tests:
+  - BBR-UBI-005
+UTL-R001:
+  description: check_bbi_args parses correctly
+  tests:
+  - BBR-UTL-001
+UTL-R002:
+  description: format_cmd_args parses correctly
+  tests:
+  - BBR-UTL-002
+UTL-R003:
+  description: parse_args_list() merges lists as expected
+  tests:
+  - BBR-UTL-003
+UTL-R004:
+  description: parse_args_list() handles NULL as expected
+  tests:
+  - BBR-UTL-004
+UTL-R005:
+  description: parse_args_list() correctly fails if .func_args isn't named
+  tests:
+  - BBR-UTL-005
+UTL-R006:
+  description: combine_list_objects() merges lists as expected
+  tests:
+  - BBR-UTL-006
+UTL-R007:
+  description: combine_list_objects() merges with append=TRUE
+  tests:
+  - BBR-UTL-007
+UTL-R008:
+  description: combine_list_objects() correctly fails if .func_args isn't named
+  tests:
+  - BBR-UTL-008
+UTL-R009:
+  description: check_required_keys() works correctly
+  tests:
+  - BBR-UTL-009
+UTL-R010:
+  description: strict_mode_error() works correctly
+  tests:
+  - BBR-UTL-010
+UTL-R011:
+  description: suppressSpecificWarning() works
+  tests:
+  - BBR-UTL-011
+UTL-R012:
+  description: wait_for_nonmem() correctly reads in stop time
+  tests:
+  - BBR-UTL-012
+UTL-R013:
+  description: wait_for_nonmem() doesn't error out if no stop time found
+  tests:
+  - BBR-UTL-013
+WRKF-R001:
+  description: step by step create_model to submit_model to model_summary works
+  tests:
+  - BBR-WRKF-001
+WRKF-R002:
+  description: copying model works and new models run correctly
+  tests:
+  - BBR-WRKF-002
+WRKF-R003:
+  description: config_log() works correctly
+  tests:
+  - BBR-WRKF-003
+WRKF-R004:
+  description: .wait = FALSE returns correctly
+  tests:
+  - BBR-WRKF-004
+WRKF-R005:
+  description: run_log() captures runs correctly
+  tests:
+  - BBR-WRKF-005
+WRKF-R006:
+  description: add_config() works with in progress model run
+  tests:
+  - BBR-WRKF-006
+WRKF-R007:
+  description: submit_model() works with non-NULL .config_path
+  tests:
+  - BBR-WRKF-007

--- a/inst/validation/bbr-stories.yaml
+++ b/inst/validation/bbr-stories.yaml
@@ -3,30 +3,30 @@ CFG-S001:
   description: As a user, I can create a default bbi.yaml file in a specified directory.
     The function that creates this should check that it points to a valid NONMEM directory.
   ProductRisk: Low
-  tests:
-  - BBR-BBR-005
-  - BBR-BBR-006
-  - BBR-BBR-007
+  requirements:
+  - BBR-R005
+  - BBR-R006
+  - BBR-R007
 CFG-S002:
   name: Version constrain bbi
   description: As a user, I want to be prevented from using a version of bbi that
     is incompatible with the version of bbr I am using.
   ProductRisk: Medium
-  tests:
-  - BBR-BBR-003
-  - BBR-BBR-004
+  requirements:
+  - BBR-R003
+  - BBR-R004
 CFG-S003:
   name: Find bbi.yaml
   description: As a user, I want any calls that need the bbi.yaml configuration file
     to, by default, look for it in the same directory as the relevant model, and to
     be able to override this by passing a path to an alternative configuration file.
   ProductRisk: Low
-  tests:
-  - BBR-SBMT-001
-  - BBR-SBMT-003
-  - BBR-SBMT-008
-  - BBR-SBMT-013
-  - BBR-WRKF-007
+  requirements:
+  - SBMT-R001
+  - SBMT-R003
+  - SBMT-R008
+  - SBMT-R013
+  - WRKF-R007
 CFG-S004:
   name: Find bbi installation
   description: As a user, I want to have bbr look for bbi in my `$PATH` by default.
@@ -34,82 +34,82 @@ CFG-S004:
     whatever path I have set in `options("bbr.bbi_exe_path")`, falling back to the
     bbi in my `$PATH`, and then an OS-dependent default, in that order.
   ProductRisk: Low
-  tests:
-  - BBR-UBI-001
-  - BBR-UBI-002
+  requirements:
+  - UBI-R001
+  - UBI-R002
 CFG-S005:
   name: Pass .bbi_args to bbi_init()
   description: As a user, I want to be able to pass in `.bbi_args` to the `bbi_init()`
     function that creates a bbi.yaml file. These arguments/options would then get
     persisted in the newly created bbi.yaml to serve as the "defaults".
   ProductRisk: Low
-  tests: BBR-BBR-008
+  requirements: BBR-R008
 CFG-S006:
   name: Set execution mode globally
   description: As a user, I want to be able globally set the .mode argument to submit_model()
     and submit_models() by using options("bbr.bbi_exe_mode"). This should be able
     to be overriden by passing something to the .mode argument directly.
   ProductRisk: Low
-  tests:
-  - BBR-SBMT-005
-  - BBR-SBMT-006
-  - BBR-SBMT-007
-  - BBR-SBMT-015
+  requirements:
+  - SBMT-R005
+  - SBMT-R006
+  - SBMT-R007
+  - SBMT-R015
 MGMT-S001:
   name: Create new model object
   description: As a user, I want to be able to create a new bbr model object by pointing
     to a model file (e.g. NONMEM control stream) on disk.
   ProductRisk: High
-  tests:
-  - BBR-NWMD-004
-  - BBR-NWMD-005
+  requirements:
+  - NWMD-R004
+  - NWMD-R005
 MGMT-S002:
   name: Read model object
   description: As a user, I want to be able to create a bbr model object by reading
     a previously created model YAML file on disk.
   ProductRisk: High
-  tests:
-  - BBR-NWMD-001
-  - BBR-NWMD-006
+  requirements:
+  - NWMD-R001
+  - NWMD-R006
 MGMT-S003:
   name: Create new model by inheriting from parent model
   description: As a user, I want to be able to create a new model object and relevant
     files on disk by passing a "parent model" that the new model should be based on.
   ProductRisk: Medium
-  tests:
-  - BBR-CMF-001
-  - BBR-CMF-002
+  requirements:
+  - CMF-R001
+  - CMF-R002
 MGMT-S004:
   name: Keep YAML and object in sync
   description: As a user, I want bbr to enforce keeping the model object in R and
     the model YAML file on disk in sync with each other.
   ProductRisk: Medium
-  tests:
-  - BBR-MMF-014
-  - BBR-MMF-015
-  - BBR-MMF-016
+  requirements:
+  - MMF-R014
+  - MMF-R015
+  - MMF-R016
 MGMT-S005:
   name: Copying models doesn't overwrite by default
   description: As a user, I want to be able to copy and create models without accidentally
     overwriting existing models.
   ProductRisk: Low
-  tests:
-  - BBR-NWMD-007
-  - BBR-CMF-004
-  - BBR-CMF-005
-  - BBR-WRKF-002
+  requirements:
+  - NWMD-R007
+  - CMF-R004
+  - CMF-R005
+  - WRKF-R002
 MGMT-S006:
   name: Capture model ancestry
   description: As a user, I want to be able to record what models a given model is
     "based on" and be recorded automatically when using the `copy_model_from()` function.
   ProductRisk: Low
-  tests:
-  - BBR-NWMD-008
-  - BBR-MMF-013
-  - BBR-RNLG-003
-  - BBR-CMF-001
-  - BBR-CMF-002
-  - BBR-GBO-001
+  requirements:
+  - NWMD-R008
+  - MMF-R013
+  - RNLG-R003
+  - CMF-R001
+  - CMF-R002
+  - GBO-R001
 MGMT-S007:
   name: Model object contains unambiguous absolute model path
   description: 'As a user, I want to be able to unambiguously find the following things,
@@ -117,48 +117,48 @@ MGMT-S007:
     the NONMEM control stream), the bbr-created YAML file, the directory containing
     model output.'
   ProductRisk: Low
-  tests:
-  - BBR-GPFO-001
-  - BBR-GPFO-002
-  - BBR-GPFO-003
-  - BBR-NWMD-004
+  requirements:
+  - GPFO-R001
+  - GPFO-R002
+  - GPFO-R003
+  - NWMD-R004
 MGMT-S008:
   name: Add and replace tags
   description: As a user, I want to be able to add, delete, and replace tags on a
     model object. Tags should be persisted in the model YAML file.
   ProductRisk: Low
-  tests:
-  - BBR-MMF-004
-  - BBR-MMF-022
-  - BBR-TDF-001
-  - BBR-CMF-001
-  - BBR-WRKF-002
+  requirements:
+  - MMF-R004
+  - MMF-R022
+  - TDF-R001
+  - CMF-R001
+  - WRKF-R002
 MGMT-S009:
   name: Add and replace notes
   description: As a user, I want to be able to add, delete, and replace notes on a
     model object. Notes should be persisted in the model YAML file.
   ProductRisk: Low
-  tests:
-  - BBR-MMF-006
-  - BBR-MMF-007
-  - BBR-CTS-001
+  requirements:
+  - MMF-R006
+  - MMF-R007
+  - CTS-R001
 MGMT-S010:
   name: Print method for model object
   description: As a user, I want to be able to print the `bbi_nonmem_model` object
     to the console and have it show the path to the model files on disk, as well as
     any attached metadata like tags, notes, etc.
   ProductRisk: Low
-  tests: BBR-PRNT-002
+  requirements: PRNT-R002
 MGMT-S011:
   name: Model diff
   description: As a user, I want to be able to see a rendered diff between two model
     files, either printed to the console or rendered in Rmd files.
   ProductRisk: Low
-  tests:
-  - BBR-MDF-001
-  - BBR-MDF-002
-  - BBR-MDF-003
-  - BBR-MDF-004
+  requirements:
+  - MDF-R001
+  - MDF-R002
+  - MDF-R003
+  - MDF-R004
 MGMT-S012:
   name: Check up to date
   description: As a user, I want a function to check whether the model file or data
@@ -166,14 +166,14 @@ MGMT-S012:
     to pass a bbi_log_df tibble to check this same thing for all of the models it
     contains.
   ProductRisk: Low
-  tests:
-  - BBR-CUTD-001
-  - BBR-CUTD-002
-  - BBR-CUTD-003
-  - BBR-CUTD-004
-  - BBR-CUTD-005
-  - BBR-CUTD-006
-  - BBR-CUTD-007
+  requirements:
+  - CUTD-R001
+  - CUTD-R002
+  - CUTD-R003
+  - CUTD-R004
+  - CUTD-R005
+  - CUTD-R006
+  - CUTD-R007
 MGMT-S013:
   name: Tags diff
   description: As a user, I want to be able to see the difference in the tags element
@@ -181,11 +181,11 @@ MGMT-S013:
     all models in a `bbi_run_log_df` to their "parent models" (i.e. the models in
     that same tibble that match their `based_on`).
   ProductRisk: Low
-  tests:
-  - BBR-TDF-001
-  - BBR-TDF-002
-  - BBR-TDF-003
-  - BBR-TDF-004
+  requirements:
+  - TDF-R001
+  - TDF-R002
+  - TDF-R003
+  - TDF-R004
 MGMT-S014:
   name: Copying models increments to next integer by default
   description: As a user, I want when passing a parent model that is named numerically
@@ -194,174 +194,174 @@ MGMT-S014:
     default, and be able to be overriden by passing a custom name to the `.new_model`
     argument.
   ProductRisk: Low
-  tests:
-  - BBR-CMF-007
-  - BBR-WRKF-002
+  requirements:
+  - CMF-R007
+  - WRKF-R002
 MGMT-S015:
   name: Update model ID in control stream
   description: As a user, I want to be able to update all occurrences of the model
     ID from a parent model and replace them with model ID from the new model in the
     new model's control stream.
   ProductRisk: Low
-  tests:
-  - BBR-CMH-001
-  - BBR-CMH-002
-  - BBR-CMH-003
-  - BBR-CMH-004
-  - BBR-CMH-005
-  - BBR-CMH-006
+  requirements:
+  - CMH-R001
+  - CMH-R002
+  - CMH-R003
+  - CMH-R004
+  - CMH-R005
+  - CMH-R006
 MGMT-S016:
   name: Cleanup model files
   description: As a user, I want to be able to easily delete all model files associated
     the identified model objects.
   ProductRisk: Medium
-  tests:
-  - BBR-CLM-001
-  - BBR-CLM-002
-  - BBR-CLM-003
-  - BBR-CLM-004
+  requirements:
+  - CLM-R001
+  - CLM-R002
+  - CLM-R003
+  - CLM-R004
 RUN-S001:
   name: Submit model to be run
   description: As a user, I want to be able to submit a model object to have bbi execute
     the relevant model.
   ProductRisk: High
-  tests:
-  - BBR-SBMT-001
-  - BBR-SBMT-002
-  - BBR-SBMT-005
-  - BBR-WRKF-001
-  - BBR-WRKF-002
+  requirements:
+  - SBMT-R001
+  - SBMT-R002
+  - SBMT-R005
+  - WRKF-R001
+  - WRKF-R002
 RUN-S002:
   name: Submit multiple models to be run
   description: As a user, I want to be able to submit multiple models for execution,
     as a batch. This should be done in as few bbi calls as possible, in order to leverage
     bbi's queueing and batch execution capabilities.
   ProductRisk: Medium
-  tests:
-  - BBR-SBMT-008
-  - BBR-SBMT-010
-  - BBR-SBMT-011
-  - BBR-SBMT-012
-  - BBR-WRKF-002
-  - BBR-TSTT-001
+  requirements:
+  - SBMT-R008
+  - SBMT-R010
+  - SBMT-R011
+  - SBMT-R012
+  - WRKF-R002
+  - TSTT-R001
 RUN-S003:
   name: Print method for bbi process
   description: As a user, I want to be able to print the babylon_process object and
     get a top-level summary of what is going on with the process.
   ProductRisk: Low
-  tests: BBR-PRNT-001
+  requirements: PRNT-R001
 SUM-S001:
   name: Summarize model outputs
   description: As a user, I want to be able to load outputs and diagnostics from a
     finished NONMEM model into an R object.
   ProductRisk: High
-  tests:
-  - BBR-SUM-001
-  - BBR-SUM-006
-  - BBR-WRKF-001
-  - BBR-WRKF-002
-  - BBR-CRT-001
-  - BBR-CRT-002
-  - BBR-CRT-003
+  requirements:
+  - SUM-R001
+  - SUM-R006
+  - WRKF-R001
+  - WRKF-R002
+  - CRT-R001
+  - CRT-R002
+  - CRT-R003
 SUM-S002:
   name: Read NONMEM parameter table
   description: As a user, I want to be able to load the parameter estimates from the
     final estimation method of a NONMEM model into a tibble in R.
   ProductRisk: Low
-  tests:
-  - BBR-PEST-001
-  - BBR-WRKF-001
-  - BBR-WRKF-002
+  requirements:
+  - PEST-R001
+  - WRKF-R001
+  - WRKF-R002
 SUM-S003:
   name: Parse parameter labels from control stream
   description: As a user, I want to be able to parse parameter names from comments
     in a NONMEM control stream, when they are in a specified format.
   ProductRisk: Low
-  tests:
-  - BBR-PLB-005
-  - BBR-PLB-006
+  requirements:
+  - PLB-R005
+  - PLB-R006
 SUM-S004:
   name: Parse .ext file with custom name
   description: As a user, I want to be able to pass a custom name for the NONMEM .ext
     file to the `model_summary()` call.
   ProductRisk: Low
-  tests: BBR-SUM-002
+  requirements: SUM-R002
 SUM-S005:
   name: Get data path helper
   description: As a user, I want to have a function that extracts the path to the
     model's input data file from the model object or summary object.
   ProductRisk: Low
-  tests:
-  - BBR-GPFO-015
-  - BBR-GPFO-016
+  requirements:
+  - GPFO-R015
+  - GPFO-R016
 SUM-S006:
   name: Build path helper
   description: As a user, I want a helper function that can build a path to an arbitrary
     NONMEM output file given a model or summary object and that file's extension.
   ProductRisk: Low
-  tests:
-  - BBR-GPFO-018
-  - BBR-GPFO-019
+  requirements:
+  - GPFO-R018
+  - GPFO-R019
 SUM-S007:
   name: Print method for model summary
   description: As a user, I want to be able to print the `bbi_nonmem_summary` object
     and get a top-line summary of what happened in the associated NONMEM run. To be
     plain text and resemble the output from `bbi nonmem summary` on the command line.
   ProductRisk: Low
-  tests: BBR-PRNT-003
+  requirements: PRNT-R003
 SUM-S008:
   name: Read NONMEM parameter table batch
   description: As a user, I want to be able to quickly read in the parameter estimates
     for all NONMEM models in a given directory into a single tibble in R.
   ProductRisk: Low
-  tests:
-  - BBR-PEST-005
-  - BBR-PEST-006
-  - BBR-PEST-007
-  - BBR-PEST-008
+  requirements:
+  - PEST-R005
+  - PEST-R006
+  - PEST-R007
+  - PEST-R008
 SUM-S009:
   name: Read NONMEM .cov and .cor
   description: As a user I want to be able to pull in the contents of the .cov and
     .cor NONMEM output files.
   ProductRisk: Low
-  tests:
-  - BBR-CVCR-001
-  - BBR-CVCR-002
-  - BBR-CVCR-003
-  - BBR-CVCR-004
+  requirements:
+  - CVCR-R001
+  - CVCR-R002
+  - CVCR-R003
+  - CVCR-R004
 OUT-S001:
   name: Read NONMEM output files
   description: As a user, I want to be able to read NONMEM output files into a tibble
     in R.
   ProductRisk: Low
-  tests: BBR-NMF-001
+  requirements: NMF-R001
 OUT-S002:
   name: Read NONMEM tables and data
   description: As a user, I want to be able to pass a model object and have bbr extract
     the input data path and path to any table outputs from the control stream and
     read those files into tibbles.
   ProductRisk: Low
-  tests:
-  - BBR-NMT-001
-  - BBR-NMT-002
-  - BBR-NMT-003
+  requirements:
+  - NMT-R001
+  - NMT-R002
+  - NMT-R003
 OUT-S003:
   name: Join NONMEM tables to input data
   description: As a user, I want to be able to pass a model object and have bbr extract
     the input data path and path to any table outputs from the control stream and
     join the contents of those files together into a single tibble.
   ProductRisk: Low
-  tests: BBR-NMJ-001
+  requirements: NMJ-R001
 LOG-S001:
   name: Parse model YAML files into run log table
   description: As a user, I want parse all model YAML files in a directory (and optionally
     subdirectories) into a run log table. The table should contain all required YAML
     fields.
   ProductRisk: Low
-  tests:
-  - BBR-WRKF-005
-  - BBR-RNLG-001
-  - BBR-RNLG-003
+  requirements:
+  - WRKF-R005
+  - RNLG-R001
+  - RNLG-R003
 LOG-S002:
   name: Working directory and paths in run log tibble are correct
   description: As a user, I want to be able to use the paths included in the run_log()
@@ -369,12 +369,12 @@ LOG-S002:
     to do this, even when the models were run on a different machine or in a different
     directory than the one in which they are currently being read (by run_log()).
   ProductRisk: Low
-  tests:
-  - BBR-RNLG-004
-  - BBR-SMLG-002
-  - BBR-CGLG-002
-  - BBR-WRKF-003
-  - BBR-WRKF-005
+  requirements:
+  - RNLG-R004
+  - SMLG-R002
+  - CGLG-R002
+  - WRKF-R003
+  - WRKF-R005
 LOG-S003:
   name: Config log
   description: As a user, I want to be able to load a log table that captures the
@@ -382,43 +382,43 @@ LOG-S003:
     models in a given directory. This should include the version of bbi and the version
     of NONMEM (if applicable) used to run the model.
   ProductRisk: Medium
-  tests:
-  - BBR-WRKF-003
-  - BBR-CGLG-002
-  - BBR-CGLG-003
-  - BBR-CGLG-006
-  - BBR-CGLG-007
+  requirements:
+  - WRKF-R003
+  - CGLG-R002
+  - CGLG-R003
+  - CGLG-R006
+  - CGLG-R007
 LOG-S004:
   name: Check if models are up-to-date using config log
   description: As a user, I want the config log to contain two columns which verify
     (using the md5 digests and file paths already present in that tibble) whether
     the file at the relevant file path matches the md5 digest stored in the tibble.
   ProductRisk: Medium
-  tests:
-  - BBR-CGLG-004
-  - BBR-CGLG-005
+  requirements:
+  - CGLG-R004
+  - CGLG-R005
 LOG-S005:
   name: Summary log
   description: As a user, I want to be able to extract a portion of the information
     summarized by `model_summaries()` into a log table, and to be able to append this
     information to the "run log" table created by `run_log()`.
   ProductRisk: Low
-  tests:
-  - BBR-SMLG-002
-  - BBR-SMLG-003
-  - BBR-SMLG-004
-  - BBR-SMLG-005
-  - BBR-SMLG-006
-  - BBR-SMLG-007
+  requirements:
+  - SMLG-R002
+  - SMLG-R003
+  - SMLG-R004
+  - SMLG-R005
+  - SMLG-R006
+  - SMLG-R007
 LOG-S006:
   name: Collapse list columns to character
   description: As a user, I want to have a function that can take a tibble and the
     names of some list columns, and collapse the list columns to a single string per
     row.
   ProductRisk: Low
-  tests:
-  - BBR-CTS-001
-  - BBR-CTS-002
-  - BBR-CTS-003
-  - BBR-CTS-004
-  - BBR-CTS-005
+  requirements:
+  - CTS-R001
+  - CTS-R002
+  - CTS-R003
+  - CTS-R004
+  - CTS-R005

--- a/inst/validation/build-validation-docs.R
+++ b/inst/validation/build-validation-docs.R
@@ -12,7 +12,7 @@
 #######################################################
 
 PKGNAME <- "bbr"
-PKGVERSION <- "1.3.0"
+PKGVERSION <- "1.3.1.9001"
 STYLE_REF_DIR <- "docx-ref-header-image" # set to NULL if not using style ref
 
 # set up directories and clear existing output dirs, if they exist
@@ -53,7 +53,10 @@ mrgvalprep::get_sys_info(
 )
 
 # read in stories
-spec <- mrgvalprep::read_spec_yaml(file.path(val_dir, paste0(PKGNAME, "-stories.yaml")))
+spec <- mrgvalprep::read_spec_yaml(
+  file.path(val_dir, paste0(PKGNAME, "-stories.yaml")),
+  file.path(val_dir, paste0(PKGNAME, "-requirements.yaml"))
+)
 
 # make docs
 mrgvalidate::create_validation_docs(


### PR DESCRIPTION
This is an update to our validation process. Where we previously linked user stories directly to tests that confirm the associated functionality, going forward we will link user stories to requirements that need to be met to satisfy the story, and then link those requirements to tests that confirm them.