### PR TITLE
Patch/bbi tips tricks

### DIFF
--- a/vignettes/nonmem-parallel.Rmd
+++ b/vignettes/nonmem-parallel.Rmd
@@ -379,40 +379,26 @@ Once ran, you can use `check_run_times()` to inspect various run times for each 
 ```{r}
 # running it
 mod <- read_model(file.path(MODEL_DIR, 200)) # this should be the copy with capped iterations
-mods <- test_threads(mod, c(8, 16, 24))
+mods <- test_threads(mod, .threads = c(2, 4, 8))
+
+
 ```
 ```
 Submitting 3 models with 3 unique configurations.
 ```
 
-
-After the models all finish, use this `check_threads()` function to see how long each took to run.
+You can use `check_run_times()` to see how long each took to run. If you specify `.wait = TRUE`, your R console will be frozen until the model run has finished.
 
 ```{r}
-#' Check estimation time for models run with various threads values
-#'
-#' @param mods list of bbi model objects created by `test_threads()`
-#'
-#' @return A tibble with columns `threads` (number of threads) and `time`
-#'   (elapsed estimation time in seconds for test models).
-check_threads <- function(mods) {
-  purrr::map_dfr(mods, ~ {
-    s <- model_summary(.x)
-    threads <- as.numeric(stringr::str_extract(s$absolute_model_path, "\\d+(?=threads$)"))
-    tibble::tibble(threads = threads, time = s$run_details$estimation_time)
-  })
-}
 
-check_threads(mods)
+check_run_times(mods, .wait = TRUE, .return_times = "all")
 ```
+
+As outlined above, you can easily delete these dummy models via `delete_models()`. The default `.tags` argument is "test threads", meaning only model objects with that tag will be deleted. In addition, the default behavior is to prompt you if you're sure you want to delete the associated model files.
+```{r}
+delete_models(mods, .tags = "test threads")
 ```
-# A tibble: 3 x 2
-  threads    time
-    <int>   <dbl>
-1       8   149.5
-2      16    88.2
-3      24    65.9
-```
+
 
 
 

--- a/vignettes/nonmem-parallel.Rmd
+++ b/vignettes/nonmem-parallel.Rmd
@@ -368,35 +368,15 @@ system(paste("qdel -u", this_user))
 
 ## Testing different numbers of threads
 
-For a big model, try running a few iterations with different numbers of threads. This way you can see the gains from adding more threads and decide how many to use as you continue to work on this model.
+For a big model, try running a few iterations with different numbers of threads. This way you can see the gains from adding more threads and decide how many to use as you continue to work on this model. This can be done via `test_threads()`, which will do the following things:
 
-* First create a dummy copy of your model, and **cap the iterations to 10 or 20** by changing `MAX_EVAL` or `NITER` in your control stream, so that it finishes fairly quickly
-* Use the `test_threads()` function below to:
-  * Copy the model a few times with `copy_model_from()`
-  * Submit the model to run with a few different options for `threads`
+* Create a dummy copy of your model
+* **Cap the iterations** by changing `MAX_EVAL` or `NITER` in your control stream (default is 10), so that it finishes fairly quickly
+* Assign the tag 'test threads' to the newly created models, which makes for easy deletion via `delete_models(.tags = "test threads")`
+
+Once ran, you can use `check_run_times()` to inspect various run times for each of the thread options you are benchmarking
 
 ```{r}
-#' Takes a model object and runs it with various threads values
-#'
-#' @param .mod bbi_model object to copy/test
-#' @param thread_opts Integer vector of threads values to test
-#' @param .mode Passed through to bbr::submit_models(.mode)
-#'
-#' @return A list of the model objects for the submitted models.
-test_threads <- function(.mod, threads_opts, .mode = "sge") {
-  mods <- map(threads_opts, ~ {
-    .m <- copy_model_from(
-      .mod,
-      paste0(get_model_id(.mod), "_", .x, "threads")
-    ) %>%
-      add_bbi_args(list(parallel = TRUE, threads = .x))
-  })
-
-  submit_models(mods, .mode = .mode, .wait = FALSE)
-
-  mods
-}
-
 # running it
 mod <- read_model(file.path(MODEL_DIR, 200)) # this should be the copy with capped iterations
 mods <- test_threads(mod, c(8, 16, 24))


### PR DESCRIPTION
This supersedes gh-501 and has the same sets of commits.  In the process of switching to `main` as the default branch, I was changing the base.  However, I accidentally selected `gh-pages` instead of `main` as the new base (eh, sorry), and GitHub got upset by the unrelated branch and closed the PR.  However, to change to the correct base, I need to open the PR again, and GitHub isn't allowing me to do that because the branch and base do not share history.  Sorry about that.

Here's the original description from @barrettk:

closes #491

> Now that test_threads() will be an exported function, we need to update the [Running NONMEM in Parallel: bbr Tips and Tricks](https://metrumresearchgroup.github.io/bbr/articles/nonmem-parallel.html) vignette to include it.
