### PR TITLE
README: update for change in default branch

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![Build Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/bbr/status.svg)](https://github-drone.metrumrg.com/metrumresearchgroup/bbr)
-[![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/develop/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
+[![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
 `bbr` is an R interface for running `bbi`. Together they provide a solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
@@ -32,7 +32,7 @@ You can also install development versions of `bbr` by downloading the source fil
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("metrumresearchgroup/bbr", ref = "develop")
+devtools::install_github("metrumresearchgroup/bbr", ref = "main")
 ```
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ functionality is rolled out. A complete list can be found
 
 ### Featured Vignettes
 
-  - [Getting Started with
+-   [Getting Started with
     bbr](https://metrumresearchgroup.github.io/bbr/articles/getting-started.html)
     – Some basic scenarios for modeling with NONMEM using `bbr`,
     introducing you to its standard workflow and functionality.
-  - [Using the based\_on
+-   [Using the based_on
     field](https://metrumresearchgroup.github.io/bbr/articles/using-based-on.html)
     – How to use the `based_on` field to track a model’s ancestry
     through the model development process, as well how to leverage
     `config_log()` to check whether older models are still up-to-date.
-  - [Creating a Model Summary
+-   [Creating a Model Summary
     Log](https://metrumresearchgroup.github.io/bbr/articles/using-summary-log.html)
     – How to use `summary_log()` to extract model diagnostics like the
     objective function value, condition number, and parameter counts.
@@ -83,8 +83,8 @@ provide isolation. To replicate this environment,
 2.  install pkgr
 
 3.  open package in an R session and run `renv::init()`
-    
-      - install `renv` \> 0.8.3-4 into default `.libPaths()` if not
+
+    -   install `renv` \> 0.8.3-4 into default `.libPaths()` if not
         already installed
 
 4.  run `pkgr install` in terminal within package directory

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Build
 Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/bbr/status.svg)](https://github-drone.metrumrg.com/metrumresearchgroup/bbr)
-[![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/develop/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
+[![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
 `bbr` is an R interface for running `bbi`. Together they provide a
@@ -39,7 +39,7 @@ latest development version from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("metrumresearchgroup/bbr", ref = "develop")
+devtools::install_github("metrumresearchgroup/bbr", ref = "main")
 ```
 
 ## Documentation


### PR DESCRIPTION
This repo's default branch is now `main` rather than `develop`.

The first commit regenerates `README.md` so that the output matches what the latest knitr would produce (and so that those changes don't get mingled with the branch name change).