### PR TITLE
Fix some confusing requirement and test descriptions 

### DIFF
--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -736,11 +736,11 @@ ROT-R004:
   tests:
   - BBR-ROT-004
 ROT-R005:
-  description: check_output_dir()
+  description: check_output_dir() works
   tests:
   - BBR-ROT-005
 ROT-R006:
-  description: check_output_dir()
+  description: check_output_dir() works with filter
   tests:
   - BBR-ROT-006
 ROT-R007:
@@ -752,31 +752,31 @@ ROT-R008:
   tests:
   - BBR-ROT-008
 ROT-R009:
-  description: check_ext()
+  description: check_ext() works with character directory and model object
   tests:
   - BBR-ROT-009
 ROT-R010:
-  description: check_ext() summary object
+  description: check_ext() works with summary object
   tests:
   - BBR-ROT-010
 ROT-R011:
-  description: check_ext()
+  description: check_ext() works when .iter_floor argument is NULL
   tests:
   - BBR-ROT-011
 ROT-R012:
-  description: check_grd()
+  description: check_grd() works with character directory and model object
   tests:
   - BBR-ROT-012
 ROT-R013:
-  description: check_grd() summary object
+  description: check_grd() works with summary object
   tests:
   - BBR-ROT-013
 ROT-R014:
-  description: check_grd()
+  description: check_grd() works when .iter_floor argument is non-zero integer
   tests:
   - BBR-ROT-014
 ROT-R015:
-  description: check_grd()
+  description: check_grd() when .iter_floor argument is NULL
   tests:
   - BBR-ROT-015
 SBMT-R001:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -902,7 +902,7 @@ SUM-R004:
   tests:
   - BBR-SUM-004
 SUM-R005:
-  description: model_summary() fails
+  description: model_summary() fails on .lst input
   tests:
   - BBR-SUM-005
 SUM-R006:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -375,11 +375,11 @@ GPFO-R017:
   tests:
   - BBR-GPFO-017
 GPFO-R018:
-  description: build_path_from_model returns correct
+  description: build_path_from_model returns correct file from model object
   tests:
   - BBR-GPFO-018
 GPFO-R019:
-  description: build_path_from_model returns correct
+  description: build_path_from_model returns correct file from summary object
   tests:
   - BBR-GPFO-019
 GPFO-R020:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -724,7 +724,7 @@ ROT-R001:
   tests:
   - BBR-ROT-001
 ROT-R002:
-  description: check_file head=
+  description: check_file supports head and tail arguments
   tests:
   - BBR-ROT-002
 ROT-R003:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -644,16 +644,10 @@ PEST-R008:
   tests:
   - BBR-PEST-008
 PEST-R009:
-  description: param_estimates_compare() works on
-  tests:
-  - BBR-PEST-009
-PEST-R010:
-  description: param_estimates_compare() works .compare_cols argument
-  tests:
-  - BBR-PEST-010
-PEST-R011:
   description: param_estimates_compare() works
   tests:
+  - BBR-PEST-009
+  - BBR-PEST-010
   - BBR-PEST-011
 PEST-R012:
   description: param_estimates_compare() errors with different models

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -659,11 +659,11 @@ PEST-R013 :
   tests:
   - BBR-PEST-013
 PLB-R001:
-  description: build_matrix_indices() parses correctly ref
+  description: build_matrix_indices() parses correctly
   tests:
   - BBR-PLB-001
 PLB-R002:
-  description: block() parses correctly 5
+  description: block() parses correctly
   tests:
   - BBR-PLB-002
 PLB-R003:
@@ -671,7 +671,7 @@ PLB-R003:
   tests:
   - BBR-PLB-003
 PLB-R004:
-  description: parse_param_comment() called internally PEX
+  description: parse_param_comment() called internally
   tests:
   - BBR-PLB-004
 PLB-R005:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -407,7 +407,7 @@ GPFO-R025:
   tests:
   - BBR-GPFO-025
 GPFO-R026:
-  description: get_config_path()
+  description: get_config_path() works
   tests:
   - BBR-GPFO-026
 MDF-R001:
@@ -571,7 +571,7 @@ NMT-R002:
   tests:
   - BBR-NMT-002
 NMT-R003:
-  description: nm_table_files()
+  description: nm_table_files() works
   tests:
   - BBR-NMT-003
 NWMD-R001:
@@ -684,15 +684,15 @@ PLB-R006:
   tests:
   - BBR-PLB-006
 PRNT-R001:
-  description: print.bbi_process
+  description: print.bbi_process works
   tests:
   - BBR-PRNT-001
 PRNT-R002:
-  description: print.bbi_nonmem_model
+  description: print.bbi_nonmem_model works
   tests:
   - BBR-PRNT-002
 PRNT-R003:
-  description: print.bbi_nonmem_summary
+  description: print.bbi_nonmem_summary works
   tests:
   - BBR-PRNT-003
 RBP-R001:
@@ -728,11 +728,11 @@ ROT-R002:
   tests:
   - BBR-ROT-002
 ROT-R003:
-  description: tail_output()
+  description: tail_output() works
   tests:
   - BBR-ROT-003
 ROT-R004:
-  description: tail_lst()
+  description: tail_lst() works
   tests:
   - BBR-ROT-004
 ROT-R005:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -649,6 +649,7 @@ PEST-R009:
   - BBR-PEST-009
   - BBR-PEST-010
   - BBR-PEST-011
+  - BBR-PEST-014
 PEST-R012:
   description: param_estimates_compare() errors with different models
   tests:

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -139,14 +139,15 @@ test_that("get_data_path parses summary object [BBR-GPFO-017]", {
   EXT_TEST_FILE
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("build_path_from_model returns correct {tools::file_ext(.tc)} from model object [BBR-GPFO-018]"), {
-    expect_identical(build_path_from_model(MOD1, paste0(".", tools::file_ext(.tc))),
+  ext <- tools::file_ext(.tc)
+  test_that(glue::glue("build_path_from_model returns correct {ext} from model object [BBR-GPFO-018]"), {
+    expect_identical(build_path_from_model(MOD1, paste0(".", ext)),
                      normalizePath(.tc))
   })
 
-  test_that(glue::glue("build_path_from_model returns correct {tools::file_ext(.tc)} from summary object [BBR-GPFO-019]"), {
-    skip_if_not_drone_or_metworx(glue::glue("build_path_from_model.bbi_nonmem_summary {tools::file_ext(.tc)}"))
-    expect_identical(build_path_from_model(SUM1, paste0(".", tools::file_ext(.tc))),
+  test_that(glue::glue("build_path_from_model returns correct {ext} from summary object [BBR-GPFO-019]"), {
+    skip_if_not_drone_or_metworx(glue::glue("build_path_from_model.bbi_nonmem_summary {ext}"))
+    expect_identical(build_path_from_model(SUM1, paste0(".", ext)),
                      normalizePath(.tc))
   })
 }

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -140,12 +140,12 @@ test_that("get_data_path parses summary object [BBR-GPFO-017]", {
 )
 for (.tc in .test_cases) {
   ext <- tools::file_ext(.tc)
-  test_that(glue::glue("build_path_from_model returns correct {ext} from model object [BBR-GPFO-018]"), {
+  test_that(glue::glue("build_path_from_model returns correct file from model object: {ext} [BBR-GPFO-018]"), {
     expect_identical(build_path_from_model(MOD1, paste0(".", ext)),
                      normalizePath(.tc))
   })
 
-  test_that(glue::glue("build_path_from_model returns correct {ext} from summary object [BBR-GPFO-019]"), {
+  test_that(glue::glue("build_path_from_model returns correct file from summary object: {ext} [BBR-GPFO-019]"), {
     skip_if_not_drone_or_metworx(glue::glue("build_path_from_model.bbi_nonmem_summary {ext}"))
     expect_identical(build_path_from_model(SUM1, paste0(".", ext)),
                      normalizePath(.tc))

--- a/tests/testthat/test-model-summary.R
+++ b/tests/testthat/test-model-summary.R
@@ -150,7 +150,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_error(model_summary(mod2), regexp = NOT_FINISHED_ERR_MSG)
   })
 
-  test_that("model_summary() fails predictably if no .lst file present [BBR-SUM-005]", {
+  test_that("model_summary() fails on bad .lst input: no file [BBR-SUM-005]", {
     on.exit({
       fs::dir_delete(NEW_MOD2)
       fs::file_delete(ctl_ext(NEW_MOD2))
@@ -170,7 +170,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_error(model_summary(mod2), regexp = NO_LST_ERR_MSG)
   })
 
-  test_that("model_summary() fails if multiple .lst files are present [BBR-SUM-005]", {
+  test_that("model_summary() fails on bad .lst input: multiple files [BBR-SUM-005]", {
     on.exit({
       fs::dir_delete(NEW_MOD2)
       fs::file_delete(ctl_ext(NEW_MOD2))

--- a/tests/testthat/test-param-estimates-batch.R
+++ b/tests/testthat/test-param-estimates-batch.R
@@ -124,7 +124,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   # compare tests
   ###################
 
-  test_that("param_estimates_compare() works on same model [BBR-PEST-009]", {
+  test_that("param_estimates_compare() works: same model [BBR-PEST-009]", {
 
     on.exit(cleanup())
 
@@ -166,7 +166,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   })
 
 
-  test_that("param_estimates_compare() works on lots of params [BBR-PEST-009]", {
+  test_that("param_estimates_compare() works: lots of params [BBR-PEST-009]", {
 
     on.exit(cleanup())
 
@@ -186,7 +186,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
   })
 
-  test_that("param_estimates_compare() works .compare_cols argument [BBR-PEST-010]", {
+  test_that("param_estimates_compare() works: .compare_cols argument [BBR-PEST-010]", {
     param_df <- param_estimates_batch(MODEL_DIR)
 
     orig_names <- names(param_df)
@@ -214,7 +214,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("param_estimates_compare() works probs argument [BBR-PEST-011]", {
+  test_that("param_estimates_compare() works: probs argument [BBR-PEST-011]", {
     res <- param_estimates_compare(
       param_estimates_batch(MODEL_DIR),
       probs = c(.3, .4, .6)
@@ -222,7 +222,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_true(all(c("30%", "40%", "60%") %in% names(res)))
   })
 
-  test_that("param_estimates_compare() works na.rm argument [BBR-PEST-011]", {
+  test_that("param_estimates_compare() works: na.rm argument [BBR-PEST-011]", {
 
     expect_error({
       res <- param_estimates_compare(

--- a/tests/testthat/test-param-estimates-batch.R
+++ b/tests/testthat/test-param-estimates-batch.R
@@ -222,7 +222,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_true(all(c("30%", "40%", "60%") %in% names(res)))
   })
 
-  test_that("param_estimates_compare() works: na.rm argument [BBR-PEST-011]", {
+  test_that("param_estimates_compare() works: na.rm argument [BBR-PEST-014]", {
 
     expect_error({
       res <- param_estimates_compare(

--- a/tests/testthat/test-param-labels.R
+++ b/tests/testthat/test-param-labels.R
@@ -24,7 +24,7 @@ for (.tc in names(MAT_REF)) {
 }
 
 
-for (i in length(BLOCK_REF)) {
+for (i in seq_along(BLOCK_REF)) {
   test_that(glue::glue("block() parses correctly {i} [BBR-PLB-002]"), {
     expect_equal(block(i), BLOCK_REF[[i]])
   })

--- a/tests/testthat/test-param-labels.R
+++ b/tests/testthat/test-param-labels.R
@@ -15,7 +15,10 @@ MODEL_PICKS <- list(
 # test_that("parse_param_comment() parses correctly ...", {...})
 
 for (.tc in names(MAT_REF)) {
-  test_that(glue::glue("build_matrix_indices() parses correctly {.tc} [BBR-PLB-001]"), {
+  # Remove "ref_" because all names start with "ref_" and mrgvalprep will keep
+  # the common parts, leading to a hard-to-parse test description.
+  label <- stringr::str_remove(.tc, "ref_")
+  test_that(glue::glue("build_matrix_indices() parses correctly: {label} [BBR-PLB-001]"), {
     ref_df <- MAT_REF[[.tc]]
 
     test_ind <- build_matrix_indices(ref_df$is_diag)
@@ -38,7 +41,10 @@ test_that("param_labels.character errors on vector [BBR-PLB-003]", {
 
 # test parsing labels from different OMEGA and SIGMA blocks
 for (.test_name in names(PARAM_BLOCK_REF)) {
-  test_that(glue::glue("parse_param_comment() called internally {.test_name} [BBR-PLB-004]"), {
+  # Remove "PEX_" because all names start with "PEX_" and mrgvalprep will keep
+  # the common parts, leading to a hard-to-parse test description.
+  label <- stringr::str_remove(.tc, "PEX_")
+  test_that(glue::glue("parse_param_comment() called internally: {label} [BBR-PLB-004]"), {
     .tc <- PARAM_BLOCK_REF[[.test_name]]
     res_df <- .tc$ctl %>% param_labels() %>% apply_indices(.omega = .tc$omega, .sigma = .tc$sigma)
     expect_equal(res_df, .tc$ref)

--- a/tests/testthat/test-read-output.R
+++ b/tests/testthat/test-read-output.R
@@ -61,7 +61,9 @@ test_that("check_file returns correctly [BBR-ROT-001]", {
   list(head_test = 100000, tail_test = 100000, ref = LST_FULL_VEC)
 )
 for (.tc in .test_cases) {
-  test_that(glue::glue("check_file head={.tc[['head_test']]} tail={.tc[['tail_test']]} [BBR-ROT-002]"), {
+  # Note: The odd VALUE=head order avoids mrgvalprep generating a rolled-up
+  # description that includes "head=" at the end.
+  test_that(glue::glue("check_file works: {.tc[['head_test']]}=head {.tc[['tail_test']]}=tail [BBR-ROT-002]"), {
     res <- check_file(LST_TEST_FILE, .print = FALSE, .return = TRUE, .head = .tc[['head_test']], .tail = .tc[['tail_test']])
     expect_identical(res, .tc[['ref']])
   })

--- a/tests/testthat/test-read-output.R
+++ b/tests/testthat/test-read-output.R
@@ -74,12 +74,13 @@ withr::with_file(OUTPUT_FILE, {
   readr::write_lines(LST_FULL_VEC, OUTPUT_FILE)
 
   .test_cases <- list(
-    list(.test_arg = OUTPUT_DIR, .test_name = "tail_output() character dir"),
-    list(.test_arg = OUTPUT_FILE, .test_name = "tail_output() character file"),
-    list(.test_arg = MOD1, .test_name = "tail_output() model object")
+    list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+    list(.test_arg = OUTPUT_FILE, .test_label = "character file"),
+    list(.test_arg = MOD1, .test_label = "model object")
   )
   for (.tc in .test_cases) {
-    test_that(paste(.tc[[".test_name"]], "[BBR-ROT-003]"), {
+    test_that(paste("tail_output() works:",
+                    .tc[[".test_label"]], "[BBR-ROT-003]"), {
       res <- tail_output(.tc[[".test_arg"]], .print = FALSE, .return = TRUE)
       expect_identical(res, LST_REF_DEFAULT)
     })
@@ -92,12 +93,13 @@ test_that("tail_output() doesn't error with finished NONMEM run [BBR-ROT-003]", 
 
 # check .lst
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "tail_lst() character dir"),
-  list(.test_arg = LST_TEST_FILE, .test_name = "tail_lst() character file"),
-  list(.test_arg = MOD1, .test_name = "tail_lst() model object")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = LST_TEST_FILE, .test_label = "character file"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-004]"), {
+  test_that(paste("tail_lst() works:",
+                  .tc[[".test_label"]], "[BBR-ROT-004]"), {
     res <- tail_lst(.tc[[".test_arg"]], .print = FALSE, .return = TRUE)
     expect_identical(res, LST_REF_DEFAULT)
   })
@@ -110,11 +112,12 @@ for (.tc in .test_cases) {
 
 # test regular output functionality
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_output_dir() character dir"),
-  list(.test_arg = MOD1, .test_name = "check_output_dir() model object")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-005]"), {
+  test_that(paste("check_output_dir() works:",
+                  .tc[[".test_label"]], "[BBR-ROT-005]"), {
     res <- check_output_dir(.tc[[".test_arg"]])
     expect_identical(basename(res), basename(OUTPUT_DIR_LS))
   })
@@ -122,11 +125,12 @@ for (.tc in .test_cases) {
 
 # test output functionality with regexpr passed through to dir_ls
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_output_dir() character dir with filter"),
-  list(.test_arg = MOD1, .test_name = "check_output_dir() model object with filter")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-006]"), {
+  test_that(paste("check_output_dir() works with filter:",
+                  .tc[[".test_label"]], "[BBR-ROT-006]"), {
     res <- check_output_dir(.tc[[".test_arg"]], regexp = CTL_FILTER)
     expect_identical(basename(res), basename(CTL_FILTER_RES))
   })
@@ -162,11 +166,12 @@ test_that("check_nonmem_table_output(.x_floor=0) works [BBR-ROT-008]", {
 
 # test check_ext
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_ext() character dir default .iter_floor"),
-  list(.test_arg = MOD1, .test_name = "check_ext() model object default .iter_floor")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-009]"), {
+  test_that(paste("check_ext() works with default .iter_floor:",
+                  .tc[[".test_label"]], "[BBR-ROT-009]"), {
     df <- check_ext(.tc[[".test_arg"]])
     ref_df <- dget(EXT_REF_FLOOR_0)
 
@@ -194,11 +199,12 @@ test_that("check_ext() summary object [BBR-ROT-010]", {
 })
 
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_ext() character dir default .iter_floor NULL"),
-  list(.test_arg = MOD1, .test_name = "check_ext() model object .iter_floor NULL")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-011]"), {
+  test_that(paste("check_ext() works when .iter_floor is NULL:",
+                  .tc[[".test_label"]], "[BBR-ROT-011]"), {
     df <- check_ext(.tc[[".test_arg"]], .iter_floor = NULL)
     ref_df <- dget(EXT_REF_FLOOR_NULL)
 
@@ -215,11 +221,12 @@ for (.tc in .test_cases) {
 
 # test check_grd
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_grd() character dir default .iter_floor"),
-  list(.test_arg = MOD1, .test_name = "check_grd() model object default .iter_floor")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-012]"), {
+  test_that(paste("check_grd() works with default .iter_floor:",
+                  .tc[[".test_label"]], "[BBR-ROT-012]"), {
     df <- check_grd(.tc[[".test_arg"]])
     ref_df <- dget(GRD_REF_FLOOR_0)
     expect_equal(df, ref_df)
@@ -240,11 +247,12 @@ test_that("check_grd() summary object [BBR-ROT-013]", {
 })
 
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_grd() character dir .iter_floor 10"),
-  list(.test_arg = MOD1, .test_name = "check_grd() model object .iter_floor 10")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-014]"), {
+  test_that(paste("check_grd() works when .iter_floor is non-zero integer:",
+                  .tc[[".test_label"]], "[BBR-ROT-014]"), {
     df <- check_grd(.tc[[".test_arg"]], .iter_floor = 10)
     ref_df <- dget(GRD_REF_FLOOR_10)
     expect_equal(df, ref_df)
@@ -258,11 +266,12 @@ for (.tc in .test_cases) {
 }
 
 .test_cases <- list(
-  list(.test_arg = OUTPUT_DIR, .test_name = "check_grd() character dir .iter_floor NULL"),
-  list(.test_arg = MOD1, .test_name = "check_grd() model object .iter_floor NULL")
+  list(.test_arg = OUTPUT_DIR, .test_label = "character dir"),
+  list(.test_arg = MOD1, .test_label = "model object")
 )
 for (.tc in .test_cases) {
-  test_that(paste(.tc[[".test_name"]], "[BBR-ROT-015]"), {
+  test_that(paste("check_grd() works when .iter_floor is NULL:",
+                  .tc[[".test_label"]], "[BBR-ROT-015]"), {
     df <- check_grd(.tc[[".test_arg"]], .iter_floor = NULL)
     ref_df <- dget(GRD_REF_FLOOR_NULL)
     expect_equal(df, ref_df)


### PR DESCRIPTION
This series is a follow-up to gh-493.  That PR used test descriptions to fill in requirement descriptions when doing the one-time generation of `inst/validation/bbr-requirements.yaml`.  gh-500 fixed one case where this led to a confusing/incomplete requirement description.  When I was working on gh-506, I spotted some more issues and decided to do a wider sweep.  While this probably doesn't catch all the problems, it will hopefully mean that we don't discover a new issue each time we touch `bbr-requirements.yaml`.

Most of these commits follow the same pattern: do a commit (or more) that cleans up a related set of test descriptions followed by a commit that cleans up the `bbr-requirement.yaml` entries.  Some notable things that fall outside this pattern:

```
requirements: collapse param_estimates_compare() requirement
test-param-estimates-batch.R: split up a test

  These two commits rewire the requirement and test IDs of
  `param_estimates_compare` a bit.

test-param-labels.R: actually test all block() cases

  This one fixes a test logic bug that led to a confusing requirement
  description.

requirements: append "works" to bare function name descriptions

  This one adjusts the requirements to avoid descriptions that consist
  of only the function name, but it leaves the corresponding test IDs as is.
```
