### PR TITLE
model-diff: hide content when models are identical

### DIFF
--- a/R/model-diff.R
+++ b/R/model-diff.R
@@ -117,7 +117,7 @@ model_diff_impl <- function(model_A, model_B, .viewer) {
   }
 
   if (tools::md5sum(model_A) == tools::md5sum(model_B)) {
-    message("Models are identical")
+    message("Relevant model files are identical")
     return(invisible(NULL))
   }
 

--- a/R/model-diff.R
+++ b/R/model-diff.R
@@ -116,6 +116,11 @@ model_diff_impl <- function(model_A, model_B, .viewer) {
     ))
   }
 
+  if (tools::md5sum(model_A) == tools::md5sum(model_B)) {
+    message("Models are identical")
+    return(invisible(NULL))
+  }
+
   # print some warnings if knitting
   knitting <- isTRUE(getOption('knitr.in.progress'))
   if (knitting) {

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -426,6 +426,10 @@ MDF-R004:
   description: model_diff.bbi_nonmem_model errors with multiple based_on
   tests:
   - BBR-MDF-004
+MDF-R005:
+  description: model_diff() hides content of identical models
+  tests:
+  - BBR-MDF-005
 MMF-R001:
   description: modify_model_field() works correctly
   tests:

--- a/inst/validation/bbr-stories.yaml
+++ b/inst/validation/bbr-stories.yaml
@@ -159,6 +159,7 @@ MGMT-S011:
   - MDF-R002
   - MDF-R003
   - MDF-R004
+  - MDF-R005
 MGMT-S012:
   name: Check up to date
   description: As a user, I want a function to check whether the model file or data

--- a/tests/testthat/test-model-diff.R
+++ b/tests/testthat/test-model-diff.R
@@ -48,3 +48,8 @@ test_that("model_diff.bbi_nonmem_model errors with multiple based_on [BBR-MDF-00
     regexp = paste0("multiple models.+", MODEL_DIFF_ERR_MSG)
   )
 })
+
+test_that("model_diff() hides content of identical models [BBR-MDF-005]", {
+  mod <- read_model(MOD1_ABS_PATH)
+  expect_message(model_diff(mod, mod), "identical")
+})


### PR DESCRIPTION
When passed files with identical contents, diffobj::diffFile() has a
message that says "No visible differences between objects" but then
confusingly prints a diff with the file content to the console.  Catch
this case, give a message, and return early.

Closes #516.