### PR TITLE
docs: regenerate with latest roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,5 +79,5 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 SystemRequirements: bbi (>= 3.0.2)

--- a/man/as_summary_list.Rd
+++ b/man/as_summary_list.Rd
@@ -20,6 +20,6 @@ Note this is primarily intended as a developer function, though it was exposed b
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_summary_log_df}: Convert a \code{bbi_summary_log_df} into a \code{bbi_summary_list}
-}}
+\item \code{as_summary_list(bbi_summary_log_df)}: Convert a \code{bbi_summary_log_df} into a \code{bbi_summary_list}
 
+}}

--- a/man/check_file.Rd
+++ b/man/check_file.Rd
@@ -43,14 +43,14 @@ tail_lst(.mod, ...)
 Reads the head and tail of specified file and prints it the console and/or returns it as a character vector.
 This is called internally in several S3 methods described below.
 }
-\section{Methods (by generic)}{
+\section{Functions}{
 \itemize{
-\item \code{tail_output}: Tail the OUTPUT file from a file path to a model.
+\item \code{tail_output(character)}: Tail the OUTPUT file from a file path to a model.
 
-\item \code{tail_output}: Tail the OUTPUT file from a \code{bbi_nonmem_model} object.
+\item \code{tail_output(bbi_nonmem_model)}: Tail the OUTPUT file from a \code{bbi_nonmem_model} object.
 
-\item \code{tail_lst}: Tail the .lst file from a file path to a model.
+\item \code{tail_lst(character)}: Tail the .lst file from a file path to a model.
 
-\item \code{tail_lst}: Tail the .lst file from a \code{bbi_nonmem_model} object.
+\item \code{tail_lst(bbi_nonmem_model)}: Tail the .lst file from a \code{bbi_nonmem_model} object.
+
 }}
-

--- a/man/check_nonmem_table_output.Rd
+++ b/man/check_nonmem_table_output.Rd
@@ -46,18 +46,18 @@ check_ext(.mod, .iter_floor = 0)
 
 Checks a NONMEM output file that's a whitespace-delimited file (for instance .grd or .ext)
 }
-\section{Methods (by generic)}{
+\section{Functions}{
 \itemize{
-\item \code{check_grd}: Checks .grd file from a file path
+\item \code{check_grd(character)}: Checks .grd file from a file path
 
-\item \code{check_grd}: Checks .grd file from a \code{bbi_nonmem_model}
+\item \code{check_grd(bbi_nonmem_model)}: Checks .grd file from a \code{bbi_nonmem_model}
 
-\item \code{check_grd}: Checks .grd file from a \code{bbi_nonmem_summary}
+\item \code{check_grd(bbi_nonmem_summary)}: Checks .grd file from a \code{bbi_nonmem_summary}
 
-\item \code{check_ext}: Checks .ext file from a file path
+\item \code{check_ext(character)}: Checks .ext file from a file path
 
-\item \code{check_ext}: Checks .ext file from a \code{bbi_nonmem_model} object
+\item \code{check_ext(bbi_nonmem_model)}: Checks .ext file from a \code{bbi_nonmem_model} object
 
-\item \code{check_ext}: Checks .ext file from a \code{bbi_nonmem_summary} object
+\item \code{check_ext(bbi_nonmem_summary)}: Checks .ext file from a \code{bbi_nonmem_summary} object
+
 }}
-

--- a/man/check_output_dir.Rd
+++ b/man/check_output_dir.Rd
@@ -22,8 +22,8 @@ List files in the output directory to glance at where the process is
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{character}: Takes a file path to the output directory.
+\item \code{check_output_dir(character)}: Takes a file path to the output directory.
 
-\item \code{bbi_model}: Takes a \verb{bbi_\{.model_type\}_model} object.
+\item \code{check_output_dir(bbi_model)}: Takes a \verb{bbi_\{.model_type\}_model} object.
+
 }}
-

--- a/man/copy_model_from.Rd
+++ b/man/copy_model_from.Rd
@@ -73,9 +73,9 @@ ancestry. See \href{../articles/using-based-on.html}{"Using based_on field" vign
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_model}: \code{.parent_mod} takes a \code{bbi_nonmem_model} object to use as a basis for the copy.
-}}
+\item \code{copy_model_from(bbi_nonmem_model)}: \code{.parent_mod} takes a \code{bbi_nonmem_model} object to use as a basis for the copy.
 
+}}
 \examples{
 \dontrun{
 parent <- read_model("/foo/parent")

--- a/man/cov_cor.Rd
+++ b/man/cov_cor.Rd
@@ -32,11 +32,11 @@ If no \code{.cov} or \code{.cor} files are found for the relevant model, will er
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_model}: Get cov and cor from \code{bbi_nonmem_model} object
+\item \code{cov_cor(bbi_nonmem_model)}: Get cov and cor from \code{bbi_nonmem_model} object
 
-\item \code{bbi_nonmem_summary}: Get cov and cor from \code{bbi_nonmem_summary} object (output of \code{model_summary()})
+\item \code{cov_cor(bbi_nonmem_summary)}: Get cov and cor from \code{bbi_nonmem_summary} object (output of \code{model_summary()})
+
 }}
-
 \seealso{
 \code{\link[=model_summary]{model_summary()}}, \code{\link[=check_cor_threshold]{check_cor_threshold()}}
 }

--- a/man/create_bbi_object.Rd
+++ b/man/create_bbi_object.Rd
@@ -48,21 +48,21 @@ Constructor functions for objects of fundamental bbr classes.
 }
 \section{Functions}{
 \itemize{
-\item \code{create_model_object}: Creates list object of class \verb{bbi_\{.model_type\}_model} from named list with \code{MODEL_REQ_INPUT_KEYS}
+\item \code{create_model_object()}: Creates list object of class \verb{bbi_\{.model_type\}_model} from named list with \code{MODEL_REQ_INPUT_KEYS}
 
-\item \code{create_summary_object}: Create list object of \verb{bbi_\{.model_type\}_summary} class, first checking that all the required keys are present.
+\item \code{create_summary_object()}: Create list object of \verb{bbi_\{.model_type\}_summary} class, first checking that all the required keys are present.
 
-\item \code{create_summary_list}: Create list output from \code{\link[=model_summaries]{model_summaries()}}. Each element will contain a \verb{bbi_\{.model_type\}_summary} object, as well as some metadata about possible errors.
+\item \code{create_summary_list()}: Create list output from \code{\link[=model_summaries]{model_summaries()}}. Each element will contain a \verb{bbi_\{.model_type\}_summary} object, as well as some metadata about possible errors.
 
-\item \code{create_process_object}: Create list object of \code{bbi_process} class, first checking that all the required keys are present.
+\item \code{create_process_object()}: Create list object of \code{bbi_process} class, first checking that all the required keys are present.
 
-\item \code{create_run_log_object}: Create tibble object of \code{bbi_run_log_df} class, first checking that all the required columns are present.
+\item \code{create_run_log_object()}: Create tibble object of \code{bbi_run_log_df} class, first checking that all the required columns are present.
 
-\item \code{create_config_log_object}: Create tibble object of \code{bbi_config_log_df} class, first checking that all the required columns are present.
+\item \code{create_config_log_object()}: Create tibble object of \code{bbi_config_log_df} class, first checking that all the required columns are present.
 
-\item \code{create_summary_log_object}: Create tibble object of \code{bbi_summary_log_df} class, first checking that all the required columns are present.
+\item \code{create_summary_log_object()}: Create tibble object of \code{bbi_summary_log_df} class, first checking that all the required columns are present.
 
-\item \code{create_log_df_impl}: Implementation function used to create objects of class \code{bbi_summary_log_df}, \code{bbi_config_log_df}, and \code{bbi_summary_log_df}
+\item \code{create_log_df_impl()}: Implementation function used to create objects of class \code{bbi_summary_log_df}, \code{bbi_config_log_df}, and \code{bbi_summary_log_df}
+
 }}
-
 \keyword{internal}

--- a/man/extract_from_summary.Rd
+++ b/man/extract_from_summary.Rd
@@ -27,15 +27,15 @@ These are all helper functions to extract a specific field or sub-field from a \
 }
 \section{Functions}{
 \itemize{
-\item \code{extract_param_count}: Extract count of non-fixed parameters
+\item \code{extract_param_count()}: Extract count of non-fixed parameters
 
-\item \code{extract_details}: Extract \code{run_details} field
+\item \code{extract_details()}: Extract \code{run_details} field
 
-\item \code{extract_heuristics}: Extract \code{run_heuristics} field
+\item \code{extract_heuristics()}: Extract \code{run_heuristics} field
 
-\item \code{extract_ofv}: Extract objective function value (without constant) for the final estimation method
+\item \code{extract_ofv()}: Extract objective function value (without constant) for the final estimation method
 
-\item \code{extract_condition_number}: Extract condition number for the final estimation method
+\item \code{extract_condition_number()}: Extract condition number for the final estimation method
+
 }}
-
 \keyword{internal}

--- a/man/get_based_on.Rd
+++ b/man/get_based_on.Rd
@@ -57,11 +57,11 @@ As long as the YAML has not moved since it was read into memory, these paths wil
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{default}: The default method attempts to extract the path from any object passed to it,
+\item \code{get_based_on(default)}: The default method attempts to extract the path from any object passed to it,
 but is designed for a list of class \verb{bbi_\{.model_type\}_model} or something similar.
 
-\item \code{character}: Takes a character scalar of a path to a model that can be loaded with \code{read_model(.bbi_object)}.
+\item \code{get_based_on(character)}: Takes a character scalar of a path to a model that can be loaded with \code{read_model(.bbi_object)}.
 
-\item \code{bbi_run_log_df}: Takes a tibble of class \code{bbi_run_log_df} and returns a list containing one character vector of paths for each row of the tibble.
+\item \code{get_based_on(bbi_run_log_df)}: Takes a tibble of class \code{bbi_run_log_df} and returns a list containing one character vector of paths for each row of the tibble.
+
 }}
-

--- a/man/get_data_path.Rd
+++ b/man/get_data_path.Rd
@@ -27,6 +27,6 @@ because the path to the data is constructed during model submission.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_model}: Takes \code{bbi_nonmem_model} object
-}}
+\item \code{get_data_path(bbi_model)}: Takes \code{bbi_nonmem_model} object
 
+}}

--- a/man/get_model_id.Rd
+++ b/man/get_model_id.Rd
@@ -25,8 +25,8 @@ Helper to strip path and extension from model file to get only model identifier
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{character}: Takes file path to model.
+\item \code{get_model_id(character)}: Takes file path to model.
 
-\item \code{bbi_model}: Takes \verb{bbi_\{.model_type\}_model} or \verb{bbi_\{.model_type\}_summary} object
+\item \code{get_model_id(bbi_model)}: Takes \verb{bbi_\{.model_type\}_model} or \verb{bbi_\{.model_type\}_summary} object
+
 }}
-

--- a/man/model_summaries.Rd
+++ b/man/model_summaries.Rd
@@ -72,11 +72,11 @@ Additionally, \strong{if you have renamed your \code{.ext} file, you will need t
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{list}: Summarize a list of \verb{bbi_\{.model_type\}_model} objects.
+\item \code{model_summaries(list)}: Summarize a list of \verb{bbi_\{.model_type\}_model} objects.
 
-\item \code{bbi_run_log_df}: Takes a \code{bbi_run_log_df} tibble and summarizes all models in it.
+\item \code{model_summaries(bbi_run_log_df)}: Takes a \code{bbi_run_log_df} tibble and summarizes all models in it.
+
 }}
-
 \seealso{
 \code{\link[=model_summary]{model_summary()}}, \code{\link[=summary_log]{summary_log()}}, \code{\link[=param_estimates_batch]{param_estimates_batch()}}
 }

--- a/man/model_summary.Rd
+++ b/man/model_summary.Rd
@@ -149,9 +149,9 @@ Additionally, if you have renamed the \code{.ext} file from its default of \verb
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_model}: Get model summary from \code{bbi_nonmem_model} object
-}}
+\item \code{model_summary(bbi_nonmem_model)}: Get model summary from \code{bbi_nonmem_model} object
 
+}}
 \seealso{
 \code{\link[=model_summaries]{model_summaries()}}, \code{\link[=summary_log]{summary_log()}}, \code{\link[=cov_cor]{cov_cor()}}, \code{\link[=param_estimates]{param_estimates()}}
 }

--- a/man/modify_based_on.Rd
+++ b/man/modify_based_on.Rd
@@ -40,13 +40,13 @@ which demonstrates the motivation and usage of this field.
 }
 \section{Functions}{
 \itemize{
-\item \code{add_based_on}: Append new \code{based_on} identifiers to a model object and corresponding YAML.
+\item \code{add_based_on()}: Append new \code{based_on} identifiers to a model object and corresponding YAML.
 
-\item \code{replace_all_based_on}: Replaces entire \code{based_on} field in a model object and corresponding YAML with new values.
+\item \code{replace_all_based_on()}: Replaces entire \code{based_on} field in a model object and corresponding YAML with new values.
 
-\item \code{remove_based_on}: Remove specified \code{based_on} identifier(s) from a model object and corresponding YAML.
+\item \code{remove_based_on()}: Remove specified \code{based_on} identifier(s) from a model object and corresponding YAML.
+
 }}
-
 \seealso{
 \code{\link[=copy_model_from]{copy_model_from()}} \code{\link[=modify_tags]{modify_tags()}} \code{\link[=modify_notes]{modify_notes()}} \code{\link[=modify_description]{modify_description()}} \code{\link[=modify_bbi_args]{modify_bbi_args()}} \code{\link[=modify_star]{modify_star()}}
 }

--- a/man/modify_bbi_args.Rd
+++ b/man/modify_bbi_args.Rd
@@ -40,14 +40,14 @@ overwrite any previous value stored for that argument.
 }
 \section{Functions}{
 \itemize{
-\item \code{add_bbi_args}: Modifies model object and corresponding YAML
+\item \code{add_bbi_args()}: Modifies model object and corresponding YAML
 by adding named list passed to \code{.bbi_args}, overwriting any args that are
 already present with the new values.
 
-\item \code{replace_all_bbi_args}: Modifies model object and corresponding YAML
+\item \code{replace_all_bbi_args()}: Modifies model object and corresponding YAML
 by replacing all \code{bbi_args} with named list passed to \code{.bbi_args}.
-}}
 
+}}
 \seealso{
 \code{\link[=submit_model]{submit_model()}} \code{\link[=model_summary]{model_summary()}} \code{\link[=print_bbi_args]{print_bbi_args()}}
 \code{\link[=modify_tags]{modify_tags()}} \code{\link[=modify_notes]{modify_notes()}} \code{\link[=modify_based_on]{modify_based_on()}} \code{\link[=modify_description]{modify_description()}} \code{\link[=modify_star]{modify_star()}}

--- a/man/modify_description.Rd
+++ b/man/modify_description.Rd
@@ -36,11 +36,11 @@ example to look at only the most important models by calling
 }
 \section{Functions}{
 \itemize{
-\item \code{add_description}: Fills the description field in a model object and corresponding YAML, if it is currently empty.
+\item \code{add_description()}: Fills the description field in a model object and corresponding YAML, if it is currently empty.
 
-\item \code{replace_description}: Replaces description field in a model object and corresponding YAML with new description.
+\item \code{replace_description()}: Replaces description field in a model object and corresponding YAML with new description.
+
 }}
-
 \seealso{
 \code{\link[=run_log]{run_log()}} \code{\link[=modify_tags]{modify_tags()}} \code{\link[=modify_notes]{modify_notes()}} \code{\link[=modify_based_on]{modify_based_on()}} \code{\link[=modify_bbi_args]{modify_bbi_args()}} \code{\link[=modify_star]{modify_star()}}
 }

--- a/man/modify_model_field.Rd
+++ b/man/modify_model_field.Rd
@@ -55,9 +55,9 @@ digest of the newly written YAML.
 }
 \section{Functions}{
 \itemize{
-\item \code{replace_model_field}: Replace a single item in a model field
-}}
+\item \code{replace_model_field()}: Replace a single item in a model field
 
+}}
 \seealso{
 \code{\link[=add_tags]{add_tags()}} \code{\link[=replace_tag]{replace_tag()}} \code{\link[=replace_all_tags]{replace_all_tags()}} \code{\link[=remove_tags]{remove_tags()}}
 \code{\link[=add_notes]{add_notes()}} \code{\link[=replace_note]{replace_note()}} \code{\link[=replace_all_notes]{replace_all_notes()}} \code{\link[=remove_notes]{remove_notes()}}

--- a/man/modify_notes.Rd
+++ b/man/modify_notes.Rd
@@ -47,16 +47,16 @@ for an example of this.
 }
 \section{Functions}{
 \itemize{
-\item \code{add_notes}: Add notes to a model object and corresponding YAML.
+\item \code{add_notes()}: Add notes to a model object and corresponding YAML.
 
-\item \code{replace_note}: Replaces a specific \code{.old_note} with \code{.new_note} on a model object and corresponding YAML.
+\item \code{replace_note()}: Replaces a specific \code{.old_note} with \code{.new_note} on a model object and corresponding YAML.
 Warns and does nothing if \code{.old_note} is not present.
 
-\item \code{replace_all_notes}: Replaces all notes on a model object and corresponding YAML with new notes.
+\item \code{replace_all_notes()}: Replaces all notes on a model object and corresponding YAML with new notes.
 
-\item \code{remove_notes}: Removes notes from a model object and corresponding YAML.
+\item \code{remove_notes()}: Removes notes from a model object and corresponding YAML.
+
 }}
-
 \seealso{
 \code{\link[=run_log]{run_log()}} \code{\link[=collapse_to_string]{collapse_to_string()}} \code{\link[=modify_tags]{modify_tags()}} \code{\link[=modify_based_on]{modify_based_on()}} \code{\link[=modify_description]{modify_description()}} \code{\link[=modify_bbi_args]{modify_bbi_args()}} \code{\link[=modify_star]{modify_star()}}
 }

--- a/man/modify_star.Rd
+++ b/man/modify_star.Rd
@@ -22,11 +22,11 @@ This is typically used for highlighting models that are of some importance to th
 }
 \section{Functions}{
 \itemize{
-\item \code{add_star}: Adds a star to the model.
+\item \code{add_star()}: Adds a star to the model.
 
-\item \code{remove_star}: Removes a star from the model.
+\item \code{remove_star()}: Removes a star from the model.
+
 }}
-
 \seealso{
 \code{\link[=run_log]{run_log()}} \code{\link[=collapse_to_string]{collapse_to_string()}} \code{\link[=modify_tags]{modify_tags()}} \code{\link[=modify_notes]{modify_notes()}}
 \code{\link[=modify_based_on]{modify_based_on()}} \code{\link[=modify_description]{modify_description()}} \code{\link[=modify_bbi_args]{modify_bbi_args()}}

--- a/man/modify_tags.Rd
+++ b/man/modify_tags.Rd
@@ -55,16 +55,16 @@ for an example of this.
 }
 \section{Functions}{
 \itemize{
-\item \code{add_tags}: Add tags to a model object and corresponding YAML.
+\item \code{add_tags()}: Add tags to a model object and corresponding YAML.
 
-\item \code{replace_tag}: Replaces a specific \code{.old_tag} with \code{.new_tag} on a model object and corresponding YAML.
+\item \code{replace_tag()}: Replaces a specific \code{.old_tag} with \code{.new_tag} on a model object and corresponding YAML.
 Warns and does nothing if \code{.old_tag} is not present.
 
-\item \code{replace_all_tags}: Replaces all tags on a model object and corresponding YAML with new tags.
+\item \code{replace_all_tags()}: Replaces all tags on a model object and corresponding YAML with new tags.
 
-\item \code{remove_tags}: Removes tags from a model object and corresponding YAML.
+\item \code{remove_tags()}: Removes tags from a model object and corresponding YAML.
+
 }}
-
 \seealso{
 \code{\link[=run_log]{run_log()}} \code{\link[=collapse_to_string]{collapse_to_string()}} \code{\link[=modify_notes]{modify_notes()}} \code{\link[=modify_based_on]{modify_based_on()}} \code{\link[=modify_description]{modify_description()}} \code{\link[=modify_bbi_args]{modify_bbi_args()}} \code{\link[=modify_star]{modify_star()}}
 }

--- a/man/nm_file.Rd
+++ b/man/nm_file.Rd
@@ -55,19 +55,19 @@ consider using
 }
 \section{Functions}{
 \itemize{
-\item \code{nm_grd}: Reads \code{.grd} file from a \code{bbi_nonmem_model} or
+\item \code{nm_grd()}: Reads \code{.grd} file from a \code{bbi_nonmem_model} or
 \code{bbi_nonmem_summary} object
 
-\item \code{nm_tab}: Reads \verb{\{get_model_id(.mod)\}.tab} file from a
+\item \code{nm_tab()}: Reads \verb{\{get_model_id(.mod)\}.tab} file from a
 \code{bbi_nonmem_model} or \code{bbi_nonmem_summary} object
 
-\item \code{nm_par_tab}: Reads \verb{\{get_model_id(.mod)\}par.tab} file from a
+\item \code{nm_par_tab()}: Reads \verb{\{get_model_id(.mod)\}par.tab} file from a
 \code{bbi_nonmem_model} or \code{bbi_nonmem_summary} object
 
-\item \code{nm_data}: Reads the input data file from a \code{bbi_nonmem_model} or
+\item \code{nm_data()}: Reads the input data file from a \code{bbi_nonmem_model} or
 \code{bbi_nonmem_summary} object
+
 }}
-
 \seealso{
 \code{\link[=nm_tables]{nm_tables()}}, \code{\link[=nm_table_files]{nm_table_files()}}, \code{\link[=nm_join]{nm_join()}}
 }

--- a/man/nm_tables.Rd
+++ b/man/nm_tables.Rd
@@ -48,10 +48,10 @@ for alternatives.
 }
 \section{Functions}{
 \itemize{
-\item \code{nm_table_files}: Extract paths to table output files from NONMEM control
+\item \code{nm_table_files()}: Extract paths to table output files from NONMEM control
 stream, and optionally check if the files exist.
-}}
 
+}}
 \seealso{
 \code{\link[=nm_join]{nm_join()}}, \code{\link[=nm_file]{nm_file()}}
 }

--- a/man/param_estimates.Rd
+++ b/man/param_estimates.Rd
@@ -45,9 +45,9 @@ error will be thrown.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_summary}: Takes \code{bbi_nonmem_summary} object, the output of \code{\link[=model_summary.bbi_nonmem_model]{model_summary.bbi_nonmem_model()}}.
-}}
+\item \code{param_estimates(bbi_nonmem_summary)}: Takes \code{bbi_nonmem_summary} object, the output of \code{\link[=model_summary.bbi_nonmem_model]{model_summary.bbi_nonmem_model()}}.
 
+}}
 \seealso{
 \code{\link[=param_estimates_batch]{param_estimates_batch()}}, \code{\link[=model_summary]{model_summary()}}, \code{\link[=param_labels]{param_labels()}}, \code{\link[=apply_indices]{apply_indices()}}
 }

--- a/man/param_labels.Rd
+++ b/man/param_labels.Rd
@@ -63,8 +63,8 @@ and transform the estimates accordingly. None of that processing is done automat
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_model}: Takes a \code{bbi_nonmem_model} object
+\item \code{param_labels(bbi_nonmem_model)}: Takes a \code{bbi_nonmem_model} object
 
-\item \code{character}: Takes a character scalar of the raw control stream with newline character separating lines
+\item \code{param_labels(character)}: Takes a character scalar of the raw control stream with newline character separating lines
+
 }}
-

--- a/man/plot_nonmem_table_df.Rd
+++ b/man/plot_nonmem_table_df.Rd
@@ -26,8 +26,8 @@ Creates a line plot of the wide-format tibble output from \code{check_nonmem_tab
 }
 \section{Functions}{
 \itemize{
-\item \code{plot_grd}: Plot the .grd file
+\item \code{plot_grd()}: Plot the .grd file
 
-\item \code{plot_ext}: Plot the .ext file
+\item \code{plot_ext()}: Plot the .ext file
+
 }}
-

--- a/man/print_bbi.Rd
+++ b/man/print_bbi.Rd
@@ -41,10 +41,10 @@ will make for prettier formatting, especially of table outputs.
 }
 \section{Functions}{
 \itemize{
-\item \code{print.bbi_process}: Prints the call made to bbi and whether the process is still running or has finished.
+\item \code{print(bbi_process)}: Prints the call made to bbi and whether the process is still running or has finished.
 
-\item \code{print.bbi_nonmem_model}: Prints the information contained in the model object and whether the model has been run
+\item \code{print(bbi_nonmem_model)}: Prints the information contained in the model object and whether the model has been run
 
-\item \code{print.bbi_nonmem_summary}: Prints a high level summary of a model from a bbi_nonmem_summary object
+\item \code{print(bbi_nonmem_summary)}: Prints a high level summary of a model from a bbi_nonmem_summary object
+
 }}
-

--- a/man/submit_model.Rd
+++ b/man/submit_model.Rd
@@ -56,9 +56,9 @@ Submits a model to be run by calling out to \code{bbi}.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_model}: Takes a \code{bbi_nonmem_model} object.
-}}
+\item \code{submit_model(bbi_nonmem_model)}: Takes a \code{bbi_nonmem_model} object.
 
+}}
 \seealso{
 \code{\link[=submit_models]{submit_models()}}
 }

--- a/man/submit_models.Rd
+++ b/man/submit_models.Rd
@@ -63,9 +63,9 @@ model YAML, or specified globally in \code{bbi.yaml}.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{list}: Takes a list of \code{bbi_nonmem_model} objects.
-}}
+\item \code{submit_models(list)}: Takes a list of \code{bbi_nonmem_model} objects.
 
+}}
 \seealso{
 \code{\link[=submit_model]{submit_model()}}
 }

--- a/man/verify_model_yaml_integrity.Rd
+++ b/man/verify_model_yaml_integrity.Rd
@@ -19,12 +19,12 @@ to keep track of any changes made to the YAML that are \emph{not} reflected in t
 }
 \section{Functions}{
 \itemize{
-\item \code{reconcile_yaml}: Use to manually reconcile model object in memory with its YAML file.
+\item \code{reconcile_yaml()}: Use to manually reconcile model object in memory with its YAML file.
 Extracts YAML path from model object and pulls in YAML file.
 Any shared keys are overwritten with the values from the YAML and new keys in YAML are added to the model object.
 The md5 digest is then updated to reflect the new state.
 
-\item \code{check_yaml_in_sync}: Checks that model YAML file is the same as when it was last read into the model object.
+\item \code{check_yaml_in_sync()}: Checks that model YAML file is the same as when it was last read into the model object.
 Errors if the md5 digests are not identical. This is called internally in most functions that interact with a model object.
-}}
 
+}}

--- a/man/wait_for_nonmem.Rd
+++ b/man/wait_for_nonmem.Rd
@@ -25,8 +25,8 @@ Calling \code{wait_for_nonmem()} will freeze the user's console until the model(
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{bbi_nonmem_model}: takes a \code{bbi_nonmem_model} object.
+\item \code{wait_for_nonmem(bbi_nonmem_model)}: takes a \code{bbi_nonmem_model} object.
 
-\item \code{list}: takes a \code{list} of \code{bbi_nonmem_model} objects.
+\item \code{wait_for_nonmem(list)}: takes a \code{list} of \code{bbi_nonmem_model} objects.
+
 }}
-


### PR DESCRIPTION
This repo's pkgr.yml pulls from the latest CRAN, so the generated docs
should generally be built with the latest roxygen2 available.
roxygen2 v7.2.1 came out 2022-07-18 and produces a lot off Rd changes,
most of which are probably related the describedIn changes [*].

Regenerate the documentation in a dedicated PR so that we can quickly
merge these changes and allow in-flight PRs to build on top of
them (avoiding conflicts and duplicate commits for the same Rd
changes).

[*] https://github.com/r-lib/roxygen2/blob/main/NEWS.md#roxygen2-721

---

Spotted these when working on another series and am trying to get ahead of conflicts and unnecessary noise.  Requesting a review from @barrettk, though @seth127 or @rymarinelli please feel free to jump and review instead.  After this lands, will ping internally saying to update roxygen2.