### PR TITLE
test-bbr: don't assume bbi_binary is in bbi.yaml

### DIFF
--- a/tests/testthat/test-bbr.R
+++ b/tests/testthat/test-bbr.R
@@ -65,7 +65,7 @@ test_that("bbi_init creates bbi.yaml [BBR-BBR-005]", {
 
   # read in yaml and check that it has a bbi key
   bbi_yaml <- yaml::read_yaml("bbi.yaml")
-  expect_true("bbi_binary" %in% names(bbi_yaml))
+  expect_true("clean_lvl" %in% names(bbi_yaml))
 })
 
 test_that("bbi_init errors with non-existent .dir [BBR-BBR-006]", {


### PR DESCRIPTION
A bbi_init() test checks that bbi_binary is in the generated yaml, but
that's no longer the case as of 807cbf8 (sge: use process bbi
executable in scripts unless overridden, 2022-07-30).

The particular key isn't important to this test, so check a different
key.