### PR TITLE
ci: test against minimum required bbi version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,7 +69,7 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: mpn:oldest
+name: oldest
 
 platform:
   os: linux
@@ -90,7 +90,7 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:2020-06-08
   commands:
   - chmod +x install_bbi.sh
-  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.2.0-rc.1'
+  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.0.2'
   volumes:
   - name: cache
     path: /ephemeral
@@ -331,5 +331,5 @@ trigger:
 
 depends_on:
 - mpn:latest
-- mpn:oldest
+- oldest
 - cran-latest

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,6 +16,9 @@
   }
 
   # set bbi minimum version
+  #
+  # Note: If you're updating this value, also update the version installed in
+  # the "oldest" build of .drone.yml.
   if (is.null(getOption("bbr.bbi_min_version"))) {
     options("bbr.bbi_min_version" = package_version("3.0.2"))
   }

--- a/tests/testthat/setup-workflow-ref.R
+++ b/tests/testthat/setup-workflow-ref.R
@@ -104,7 +104,12 @@ MOD4_ABS_PATH <- fs::path_norm(file.path(getwd(), LEVEL2_MOD)) %>% as.character(
 RUN_LOG_ROWS <- 3L
 RUN_LOG_COLS <- 10L
 CONFIG_COLS <- 9L
-SUM_LOG_COLS <- 23L
+SUM_LOG_COLS <- if (test_bbi_version(read_bbi_path(), .min_version = "3.0.3")) {
+  23L
+} else {
+  # eigenvalue_issue isn't present yet.
+  22L
+}
 
 ref_json <- jsonlite::fromJSON(system.file("test-refs", "ref_values.json", package = "bbr"))
 CONFIG_DATA_PATH <- ref_json$CONFIG_DATA_PATH

--- a/tests/testthat/test-param-estimates-batch.R
+++ b/tests/testthat/test-param-estimates-batch.R
@@ -1,6 +1,7 @@
 context("Test bbi batch parameter estimate functions")
 
 skip_if_not_drone_or_metworx("test-batch-param-estimates")
+skip_if_old_bbi("3.1.0")
 
 withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 

--- a/tests/testthat/test-summary-log.R
+++ b/tests/testthat/test-summary-log.R
@@ -85,8 +85,9 @@ test_that("summary_log() parses heuristics correctly [BBR-SMLG-006]", {
   expect_true(run1001$large_condition_number)
   expect_true(run1001$prderr)
   expect_true(run1001[[ANY_HEURISTICS]])
-  expect_true(filter(sum_df2, run == "acop-fake-bayes")$eigenvalue_issues)
   expect_true(filter(sum_df2, run == "iovmm")$has_final_zero_gradient)
+  skip_if_old_bbi("3.0.3")
+  expect_true(filter(sum_df2, run == "acop-fake-bayes")$eigenvalue_issues)
 })
 
 test_that("summary_log() parses more complex flags and stats [BBR-SMLG-007]", {


### PR DESCRIPTION
The first commit of this PR update the `mpn:oldest` build to use bbi version 3.0.2, the value of `bbr.bbi_min_version`.  The goal is to keep bbr compatible (and the tests passing) with the minimum version that's specified there.

The other two commits adds some skipping/conditional logic to the tests to avoid some failures when running with the minimum required bbi.

I talked with @seth127, and he is on board with the general idea, but of course please chime in with any comments on the specifics.
