### PR TITLE
Add .overwrite argument to submit_model and submit_model

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -16,6 +16,10 @@
 #'   `"local"` for local execution. This can be passed directly to this argument
 #'   or set globally with `options("bbr.bbi_exe_mode")`.
 #' @param ... args passed through to `bbi_exec()`
+#' @param .overwrite Logical to specify whether or not to overwrite existing
+#'   model output from a previous run. If `NULL`, the default, will defer to
+#'   setting in `.bbi_args` or `bbi.yaml`. If _not_ `NULL` will override any
+#'   settings in `.bbi_args` or `bbi.yaml`.
 #' @param .config_path Path to a bbi configuration file. If `NULL`, the
 #'   default, will attempt to use a `bbi.yaml` in the same directory as the
 #'   model.
@@ -31,6 +35,7 @@ submit_model <- function(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run=FALSE
@@ -45,6 +50,7 @@ submit_model.bbi_nonmem_model <- function(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run=FALSE
@@ -54,6 +60,7 @@ submit_model.bbi_nonmem_model <- function(
                              .bbi_args = .bbi_args,
                              .mode = .mode,
                              ...,
+                             .overwrite = .overwrite,
                              .config_path = .config_path,
                              .wait = .wait,
                              .dry_run = .dry_run)
@@ -71,12 +78,14 @@ submit_model.bbi_nonmem_model <- function(
 #' @param .mod An S3 object of class `bbi_nonmem_model`, for example from `new_model()`, `read_model()` or `copy_model_from()`
 #' @importFrom stringr str_detect
 #' @importFrom tools file_path_sans_ext
+#' @importFrom checkmate assert_logical
 #' @return An S3 object of class `bbi_process`
 #' @keywords internal
 submit_nonmem_model <- function(.mod,
                                 .bbi_args = NULL,
                                 .mode = getOption("bbr.bbi_exe_mode"),
                                 ...,
+                                .overwrite = NULL,
                                 .config_path = NULL,
                                 .wait = TRUE,
                                 .dry_run=FALSE) {
@@ -89,6 +98,10 @@ submit_nonmem_model <- function(.mod,
 
   # build command line args
   .bbi_args <- parse_args_list(.bbi_args, .mod[[YAML_BBI_ARGS]])
+  if (!is.null(.overwrite)) {
+    checkmate::assert_logical(.overwrite)
+    .bbi_args[["overwrite"]] <- .overwrite
+  }
   args_vec <- check_bbi_args(.bbi_args)
 
 

--- a/R/submit-models.R
+++ b/R/submit-models.R
@@ -21,6 +21,7 @@ submit_models <- function(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run=FALSE
@@ -36,6 +37,7 @@ submit_models.list <- function(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run=FALSE
@@ -60,6 +62,7 @@ submit_models.list <- function(
                                      .bbi_args = .bbi_args,
                                      .mode = .mode,
                                      ...,
+                                     .overwrite = .overwrite,
                                      .config_path = .config_path,
                                      .wait = .wait,
                                      .dry_run = .dry_run)
@@ -91,6 +94,7 @@ submit_nonmem_models <- function(.mods,
                                  .bbi_args = NULL,
                                  .mode = getOption("bbr.bbi_exe_mode"),
                                  ...,
+                                 .overwrite = NULL,
                                  .config_path = NULL,
                                  .wait = TRUE,
                                  .dry_run = FALSE) {
@@ -108,6 +112,10 @@ submit_nonmem_models <- function(.mods,
   check_mode_argument(.mode)
 
   # get unique sets of params
+  if (!is.null(.overwrite)) {
+    checkmate::assert_logical(.overwrite)
+    .bbi_args[["overwrite"]] <- .overwrite
+  }
   param_list <- build_bbi_param_list(.mods, .bbi_args)
 
   # a .run is a group of models that can be passed in a single bbi call

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -1043,3 +1043,7 @@ WRKF-R007:
   description: submit_model() works with non-NULL .config_path
   tests:
   - BBR-WRKF-007
+WRKF-R008:
+  description: submit_model() overwrites existing model when .overwrite=TRUE
+  tests:
+  - BBR-WRKF-008

--- a/inst/validation/bbr-stories.yaml
+++ b/inst/validation/bbr-stories.yaml
@@ -361,6 +361,7 @@ RUN-S001:
   - WRKF-R001
   - WRKF-R002
   - WRKF-R004
+  - WRKF-R008
 RUN-S002:
   name: Submit multiple models to be run
   description: As a user, I want to be able to submit multiple models for execution,

--- a/man/submit_model.Rd
+++ b/man/submit_model.Rd
@@ -10,6 +10,7 @@ submit_model(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE
@@ -20,6 +21,7 @@ submit_model(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE
@@ -38,6 +40,11 @@ global YAML files).}
 or set globally with \code{options("bbr.bbi_exe_mode")}.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
+
+\item{.overwrite}{Logical to specify whether or not to overwrite existing
+model output from a previous run. If \code{NULL}, the default, will defer to
+setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
+settings in \code{.bbi_args} or \code{bbi.yaml}.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/man/submit_models.Rd
+++ b/man/submit_models.Rd
@@ -10,6 +10,7 @@ submit_models(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE
@@ -20,6 +21,7 @@ submit_models(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE
@@ -38,6 +40,11 @@ global YAML files).}
 or set globally with \code{options("bbr.bbi_exe_mode")}.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
+
+\item{.overwrite}{Logical to specify whether or not to overwrite existing
+model output from a previous run. If \code{NULL}, the default, will defer to
+setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
+settings in \code{.bbi_args} or \code{bbi.yaml}.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/man/submit_nonmem_model.Rd
+++ b/man/submit_nonmem_model.Rd
@@ -9,6 +9,7 @@ submit_nonmem_model(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE

--- a/man/submit_nonmem_models.Rd
+++ b/man/submit_nonmem_models.Rd
@@ -9,6 +9,7 @@ submit_nonmem_models(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
+  .overwrite = NULL,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE
@@ -27,6 +28,11 @@ global YAML files).}
 or set globally with \code{options("bbr.bbi_exe_mode")}.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
+
+\item{.overwrite}{Logical to specify whether or not to overwrite existing
+model output from a previous run. If \code{NULL}, the default, will defer to
+setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
+settings in \code{.bbi_args} or \code{bbi.yaml}.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/tests/testthat/test-workflow-bbi.R
+++ b/tests/testthat/test-workflow-bbi.R
@@ -95,7 +95,7 @@ withr::with_options(list(
     mod2 <- mod2 %>% add_tags(NEW_TAGS)
   })
 
-  test_that(".overwrite argument works for submitting models", {
+  test_that(".overwrite argument works for submitting models [BBR-WRKF-008]", {
     mod1 <- read_model(file.path(MODEL_DIR_BBI, "1"))
     mod2 <- read_model(file.path(MODEL_DIR_BBI, "2"))
     mod3 <- read_model(file.path(MODEL_DIR_BBI, "3"))

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -158,13 +158,13 @@ See the docs for any of the functions just mentioned for more details on usage a
 
 ### Overwriting output from a previously run model
 
-It is common to run a model, make some tweaks to it, and then run it again. However, to avoid accidentally deleting model outputs, `bbr` will error by default if it sees existing output when trying to submit a model. To automatically overwrite any previous model output, just pass `overwrite = TRUE` to the `.bbi_args` argument described in the previous section. For example:
+It is common to run a model, make some tweaks to it, and then run it again. However, to avoid accidentally deleting model outputs, `bbr` will error by default if it sees existing output when trying to submit a model. To automatically overwrite any previous model output, just pass `.overwrite = TRUE` to `submit_model()`.
 
 ```{r overwrite true, eval = FALSE}
-mod1 %>% submit_model(.bbi_args = list(overwrite = TRUE))
+mod1 %>% submit_model(.overwrite = TRUE)
 ```
 
-You can also change this setting globally by setting `overwrite: true` in the `bbi.yaml` file for your project.
+You can also inherit this setting, either by attaching `overwrite = TRUE` to a model with `add_bbi_args()` or by setting it globally with `overwrite: true` in the `bbi.yaml` file for your project. However, either of these settings will be overridden by directly passing the argument as shown above.
 
 ## Summarize model
 Once the model run has completed, users can get a summary object containing much of the commonly used diagnostic information in a named list.


### PR DESCRIPTION
This extracts two commits from @seth127's [bbr_alpha_stan branch](https://github.com/metrumresearchgroup/bbr/pull/358) that address #544.

At this point, `bbr_alpha_stan` serves as the base for the bbr.bayes split (#543), so I'd prefer we not actually remove the corresponding commits (902a13d8, 1c44d1c3) from that branch.  However, it would be fine to merge this PR rather than wait on #543 to be merged.  (That'd just lead to a minor conflict and two sets of commits making these changes.)

---

I'm marking this as a draft because the plan is to merge this after the upcoming release.

Leftover bits:
- [x] add test ID and adjust stories/reqs
- [x] any other spots in the documentation that should switch to using this argument rather than `.bbi_args`?
   Edit: There are a few instances in `vignettes/nonmem-parallel.Rmd`, but I think those are okay to leave as is (given we have no plan to deprecate passing overwrite via `.bbi_args`).  I'm not spotting anything else, at least with simple grepping.

Closes #544.