### PR TITLE
summary_log: adjust extract_details for tidyr 1.3.0 compatibility

### DIFF
--- a/R/summary-log.R
+++ b/R/summary-log.R
@@ -165,7 +165,13 @@ extract_details <- function(.s) {
       return(NULL)
     }
 
-    return(.x[DETAILS_ELEMENTS])
+    # Only index with existing names to avoid $<NA> items, which will make the
+    # downstream unnest_wider() call fail.
+    idx <- intersect(names(.x), DETAILS_ELEMENTS)
+    if (!length(idx)) {
+      return(NULL)
+    }
+    return(.x[idx])
   })
 
   return(.out)


### PR DESCRIPTION
With the recent tidyr 1.3.0 release, two summary log tests are failing:

    Error ('test-summary-log.R:81'): summary_log() parses heuristics correctly [BBR-SMLG-006]
    Error in `unnest_wider(., "d")`: ℹ In column: `d`.
    ℹ In row: 4.
    Caused by error:
    ! Can't unnest elements with missing names.
    ℹ Supply `names_sep` to generate automatic names.

    Error ('test-summary-log.R:96'): summary_log() parses more complex flags and stats [BBR-SMLG-007]
    Error in `unnest_wider(., "d")`: ℹ In column: `d`.
    ℹ In row: 4.
    Caused by error:
    ! Can't unnest elements with missing names.
    ℹ Supply `names_sep` to generate automatic names.

The value triggering these failures looks like this:

    $<NA>
    NULL

    $problem_text
    [1] "PK model 1 cmt base"

    $number_of_subjects
    [1] 40

    $number_of_obs
    [1] 760

That NA comes from extract_details() indexing the run details with DETAILS_ELEMENTS, which includes "estimation_method", but the value for the acop-onlysim model doesn't have an estimation_method element.

Handle this case by only indexing with names that exist for a given model's run details.

--- 

cc @seth127 for awareness