### PR TITLE
get-path-from-object: non-existent output directory fixes

### DIFF
--- a/R/get-path-from-object.R
+++ b/R/get-path-from-object.R
@@ -111,7 +111,9 @@ get_config_path <- function(.bbi_object, .check_exists = TRUE) {
 #' @rdname get_path_from_object
 #' @export
 get_config_path.bbi_model <- function(.bbi_object, .check_exists = TRUE) {
-  .path <- file.path(get_output_dir(.bbi_object), "bbi_config.json")
+  .path <- file.path(
+    get_output_dir(.bbi_object, .check_exists = .check_exists),
+    "bbi_config.json")
 
   if (isTRUE(.check_exists)) {
     checkmate::assert_file_exists(.path)

--- a/R/get-path-from-object.R
+++ b/R/get-path-from-object.R
@@ -223,7 +223,7 @@ build_path_from_model <- function(.mod, .suffix, ...) {
 #' @export
 build_path_from_model.bbi_model <- function(.mod, .suffix, ...) {
   file.path(
-    get_output_dir(.mod),
+    get_output_dir(.mod, .check_exists = FALSE),
     paste0(get_model_id(.mod), .suffix)
   )
 }

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -412,6 +412,7 @@ GPFO-R026:
   description: get_config_path() works
   tests:
   - BBR-GPFO-026
+  - BBR-GPFO-028
 GPFO-R027:
   description: build_path_from_model works when output directory is missing
   tests:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -412,6 +412,10 @@ GPFO-R026:
   description: get_config_path() works
   tests:
   - BBR-GPFO-026
+GPFO-R027:
+  description: build_path_from_model works when output directory is missing
+  tests:
+  - BBR-GPFO-027
 MDF-R001:
   description: model_diff.bbi_nonmem_model happy path based_on
   tests:

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -902,6 +902,10 @@ SMLG-R012:
   description: summary_log() defaults to .recurse = FALSE
   tests:
   - BBR-SMLG-003
+SMLG-R013:
+  description: summary_log() works when model output directory doesn't exist
+  tests:
+  - BBR-SMLG-012
 SUM-R001:
   description: model_summary.bbi_nonmem_model produces expected output
   tests:

--- a/inst/validation/bbr-stories.yaml
+++ b/inst/validation/bbr-stories.yaml
@@ -643,6 +643,7 @@ LOG-S005:
   - SMLG-R010
   - SMLG-R011
   - SMLG-R012
+  - SMLG-R013
 LOG-S006:
   name: Collapse list columns to character
   description: As a user, I want to have a function that can take a tibble and the

--- a/inst/validation/bbr-stories.yaml
+++ b/inst/validation/bbr-stories.yaml
@@ -457,6 +457,7 @@ SUM-S006:
   - GPFO-R018
   - GPFO-R019
   - GPFO-R020
+  - GPFO-R027
 SUM-S007:
   name: Print method for model summary
   description: As a user, I want to be able to print the `bbi_nonmem_summary` object

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -21,17 +21,20 @@ test_that("get_config_path() builds the right path [BBR-GPFO-026]", {
 })
 
 test_that("get_config_path: .check_exists=FALSE works [BBR-GPFO-028]", {
-  tdir <- withr::local_tempdir("bbr-tests-")
-  fs::file_copy(CTL_TEST_FILE, file.path(tdir, "mod.ctl"))
-  mod_path <- file.path(tdir, "mod")
-  mod <- new_model(mod_path)
+  ctl_file <- fs::path_abs(CTL_TEST_FILE)
+  withr::with_tempdir({
+    fs::file_copy(ctl_file, "mod.ctl")
+    mod_path <- file.path(getwd(), "mod")
+    mod <- new_model(mod_path)
 
-  expect_identical(get_config_path(mod, .check_exists = FALSE),
-                   file.path(normalizePath(tdir), "mod", "bbi_config.json"))
+    expect_identical(get_config_path(mod, .check_exists = FALSE),
+                     file.path(normalizePath(getwd()),
+                               "mod", "bbi_config.json"))
 
-  fs::dir_create(mod_path)
-  expect_identical(get_config_path(mod, .check_exists = FALSE),
-                   file.path(normalizePath(mod_path), "bbi_config.json"))
+    fs::dir_create(mod_path)
+    expect_identical(get_config_path(mod, .check_exists = FALSE),
+                     file.path(normalizePath(mod_path), "bbi_config.json"))
+  })
 })
 
 test_that("get_yaml_path() builds the right path [BBR-GPFO-003]", {
@@ -174,11 +177,13 @@ test_that("build_path_from_model works with period in extension [BBR-GPFO-020]",
 })
 
 test_that("build_path_from_model works when output directory is missing [BBR-GPFO-027]", {
-  tdir <- withr::local_tempdir("bbr-tests-")
-  fs::file_copy(CTL_TEST_FILE, file.path(tdir, "mod.ctl"))
-  mod <- new_model(file.path(tdir, "mod"))
-  expect_identical(build_path_from_model(mod, "-foo"),
-                   file.path(normalizePath(tdir), "mod", "mod-foo"))
+  ctl_file <- fs::path_abs(CTL_TEST_FILE)
+  withr::with_tempdir({
+    fs::file_copy(ctl_file, "mod.ctl")
+    mod <- new_model("mod")
+    expect_identical(build_path_from_model(mod, "-foo"),
+                     file.path(normalizePath(getwd()), "mod", "mod-foo"))
+  })
 })
 
 test_that("is_valid_nonmem_extension() works [BBR-GPFO-021]", {

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -159,6 +159,13 @@ test_that("build_path_from_model works with period in extension [BBR-GPFO-020]",
   )
 })
 
+test_that("build_path_from_model works when output directory is missing [BBR-GPFO-027]", {
+  tdir <- withr::local_tempdir("bbr-tests-")
+  fs::file_copy(CTL_TEST_FILE, file.path(tdir, "mod.ctl"))
+  mod <- new_model(file.path(tdir, "mod"))
+  expect_identical(build_path_from_model(mod, "-foo"),
+                   file.path(normalizePath(tdir), "mod", "mod-foo"))
+})
 
 test_that("is_valid_nonmem_extension() works [BBR-GPFO-021]", {
   expect_true(is_valid_nonmem_extension(MOD_TEST_FILE))

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -26,6 +26,9 @@ test_that("get_config_path: .check_exists=FALSE works [BBR-GPFO-028]", {
   mod_path <- file.path(tdir, "mod")
   mod <- new_model(mod_path)
 
+  expect_identical(get_config_path(mod, .check_exists = FALSE),
+                   file.path(normalizePath(tdir), "mod", "bbi_config.json"))
+
   fs::dir_create(mod_path)
   expect_identical(get_config_path(mod, .check_exists = FALSE),
                    file.path(normalizePath(mod_path), "bbi_config.json"))

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -20,6 +20,17 @@ test_that("get_config_path() builds the right path [BBR-GPFO-026]", {
   expect_identical(get_config_path(MOD1), normalizePath(file.path(OUTPUT_DIR, "bbi_config.json")))
 })
 
+test_that("get_config_path: .check_exists=FALSE works [BBR-GPFO-028]", {
+  tdir <- withr::local_tempdir("bbr-tests-")
+  fs::file_copy(CTL_TEST_FILE, file.path(tdir, "mod.ctl"))
+  mod_path <- file.path(tdir, "mod")
+  mod <- new_model(mod_path)
+
+  fs::dir_create(mod_path)
+  expect_identical(get_config_path(mod, .check_exists = FALSE),
+                   file.path(normalizePath(mod_path), "bbi_config.json"))
+})
+
 test_that("get_yaml_path() builds the right path [BBR-GPFO-003]", {
   expect_identical(get_yaml_path(MOD1), normalizePath(YAML_TEST_FILE))
 })

--- a/tests/testthat/test-model-summaries.R
+++ b/tests/testthat/test-model-summaries.R
@@ -6,18 +6,25 @@ skip_if_not_drone_or_metworx("test-model-summaries")
 NUM_MODS <- 3
 
 # helper to run expectations
-test_mod_sums <- function(mod_sums) {
+#
+# `should_fail_at` lists positions in `mod_sums` that are expected to fail.
+test_mod_sums <- function(mod_sums, should_fail_at = NULL) {
   expect_equal(length(mod_sums), NUM_MODS)
 
   ref_sum <- dget(SUMMARY_REF_FILE)
 
-  for (.s in mod_sums) {
-    # replace incidental differences
-    ref_sum[[ABS_MOD_PATH]] <- .s$bbi_summary[[ABS_MOD_PATH]]
-    ref_sum$run_details$output_files_used <- NULL
-    .s$bbi_summary$run_details$output_files_used <- NULL
+  for (i in seq_along(mod_sums)) {
+    .s <- mod_sums[[i]]
+    if (i %in% should_fail_at) {
+      expect_false(.s$bbi_summary$success)
+    } else {
+      # replace incidental differences
+      ref_sum[[ABS_MOD_PATH]] <- .s$bbi_summary[[ABS_MOD_PATH]]
+      ref_sum$run_details$output_files_used <- NULL
+      .s$bbi_summary$run_details$output_files_used <- NULL
 
-    expect_equal(ref_sum, .s$bbi_summary)
+      expect_equal(ref_sum, .s$bbi_summary)
+    }
   }
 }
 
@@ -25,7 +32,6 @@ test_mod_sums <- function(mod_sums) {
 cleanup()
 create_rlg_models()
 copy_output_dir(MOD1, NEW_MOD2)
-copy_output_dir(MOD1, NEW_MOD3)
 # teardown
 withr::defer(cleanup())
 
@@ -44,7 +50,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     }
     skip_if_old_bbi("3.2.0")
     mod_sums <- model_summaries(mods)
-    test_mod_sums(mod_sums)
+    test_mod_sums(mod_sums, should_fail_at = 3)
 
   })
 
@@ -59,14 +65,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   test_that("model_summaries.bbi_run_log_df produces expected output [BBR-SUM-008]", {
     skip_if_old_bbi("3.2.0")
     mod_sums <- run_log(MODEL_DIR) %>% model_summaries()
-    test_mod_sums(mod_sums)
+    test_mod_sums(mod_sums, should_fail_at = 3)
   })
 
 
   test_that("as_summary_list.bbi_summary_log_df works [BBR-SUM-009]", {
     skip_if_old_bbi("3.2.0")
     mod_sums <- summary_log(MODEL_DIR) %>% as_summary_list()
-    test_mod_sums(mod_sums)
+    test_mod_sums(mod_sums, should_fail_at = 3)
   })
 
 }) # closing withr::with_options

--- a/tests/testthat/test-summary-log.R
+++ b/tests/testthat/test-summary-log.R
@@ -110,6 +110,18 @@ test_that("summary_log() parses more complex flags and stats [BBR-SMLG-007]", {
                tolerance = 0.01)
 })
 
+test_that("summary_log() doesn't fail on missing model output directory [BBR-SMLG-012]", {
+  ctl_file <- fs::path_abs(CTL_TEST_FILE)
+  withr::with_tempdir({
+    fs::file_copy(ctl_file, "mod.ctl")
+    new_model("mod")
+    expect_warning(res <- summary_log("."), "FAILED")
+    expect_identical(nrow(res), 1L)
+    expect_identical(res$run, "mod")
+    checkmate::expect_string(res$error_msg, min.chars = 1)
+  })
+})
+
 test_that("summary_log works some failed summaries [BBR-SMLG-008]", {
   clean_test_enviroment(create_all_models)
   copy_all_output_dirs()


### PR DESCRIPTION
This series fixes two errors triggered by a missing output directory:

 * `model_summaries()` (due to a `build_path_from_model` call underneath) failed if a model's output didn't exist.

   This is likely the error described by @barrettk at <https://github.com/metrumresearchgroup/bbr/issues/569#issuecomment-1400485335>.  The main wrinkle needed to get @seth127's [reproducer](https://github.com/metrumresearchgroup/bbr/issues/569#issuecomment-1400514483) to trigger the issue is using a bbi version of at least v3.2.0, so that the `model_summaries_concurrent()` code path is used.

 * `get_config_path(..., .check_exists = FALSE)` failed when the model's output directory didn't exist.

   This came up when working on a bbr.bayes PR.

Code-wise, the source of these errors are independent, but I'm putting them in the PR as conceptually the same (mostly to avoid validation ID conflicts :/).
