### PR TITLE
Silence dplyr 1.1.0 warnings

### DIFF
--- a/R/compat.R
+++ b/R/compat.R
@@ -1,0 +1,10 @@
+# Compatibility kludges
+
+# dplyr 1.1.0
+#
+#  * introduced reframe() and deprecated returning multiple rows via summarise()
+if (utils::packageVersion("dplyr") < "1.1.0") {
+  reframe <- dplyr::summarise
+} else {
+  reframe <- dplyr::reframe
+}

--- a/R/compat.R
+++ b/R/compat.R
@@ -3,8 +3,15 @@
 # dplyr 1.1.0
 #
 #  * introduced reframe() and deprecated returning multiple rows via summarise()
+#
+#  * added a 'multiple' argument to join functions to control the behavior when
+#    an observation in x matches multiple observations in y. For equality and
+#    rolling joins, it keeps the pre-1.1.0 behavior of returning all the rows
+#    but warns.
 if (utils::packageVersion("dplyr") < "1.1.0") {
   reframe <- dplyr::summarise
+  left_join_all <- dplyr::left_join
 } else {
   reframe <- dplyr::reframe
+  left_join_all <- function(...) dplyr::left_join(..., multiple = "all")
 }

--- a/R/nm-join.R
+++ b/R/nm-join.R
@@ -123,8 +123,12 @@ nm_join <- function(
 
   if (.superset) {
     join_fun <- function(x, y, ...) left_join(y, x, ...)
+    join_first_only_fun <- join_fun
   } else {
     join_fun <- left_join
+    # For the FIRSTONLY case, joining the data to the table is expected to match
+    # multiple table rows; use left_join_all() to avoid a warning.
+    join_first_only_fun <- left_join_all
   }
 
   # get number of ID's and records
@@ -162,7 +166,7 @@ nm_join <- function(
       # do the join
       tab <- drop_dups(tab, .d, "ID", .n)
       col_order <- union(col_order, names(tab))
-      .d <- join_fun(tab, .d, by = "ID")
+      .d <- join_first_only_fun(tab, .d, by = "ID")
     } else if (nrow(tab) == nrec) {
       # otherwise, join on .join_col
       tab <- drop_dups(tab, .d, .join_col, .n)

--- a/R/param-estimates-batch.R
+++ b/R/param-estimates-batch.R
@@ -184,6 +184,7 @@ param_estimates_compare <- function(
   # summarize comp to quantiles
   comp_df <- comp_df %>%
     summarise(across(
+      .cols = everything(),
       .fns = quantile,
       probs = probs,
       na.rm = na.rm

--- a/R/param-estimates-batch.R
+++ b/R/param-estimates-batch.R
@@ -183,7 +183,7 @@ param_estimates_compare <- function(
 
   # summarize comp to quantiles
   comp_df <- comp_df %>%
-    summarise(across(
+    reframe(across(
       .cols = everything(),
       .fns = quantile,
       probs = probs,

--- a/R/param-estimates-batch.R
+++ b/R/param-estimates-batch.R
@@ -182,13 +182,13 @@ param_estimates_compare <- function(
   }
 
   # summarize comp to quantiles
+
+  quantile_fn <- function(x)  {
+    quantile(x, probs = probs, na.rm = na.rm)
+  }
+
   comp_df <- comp_df %>%
-    reframe(across(
-      .cols = everything(),
-      .fns = quantile,
-      probs = probs,
-      na.rm = na.rm
-    )) %>%
+    reframe(across(.cols = everything(), .fns = quantile_fn)) %>%
     t() %>%
     as.data.frame() %>%
     rownames_to_column()

--- a/R/test-threads.R
+++ b/R/test-threads.R
@@ -238,10 +238,12 @@ delete_models <- function(.mods, .tags = "test threads", .force = FALSE){
   })
 
   tag_groups <- if(is.null(.tags)){
-    crossing(mod_tags = mod_info$mod_tags, .tags = "NA", found = TRUE) %>% left_join(mod_info, by = "mod_tags")
+    crossing(mod_tags = mod_info$mod_tags, .tags = "NA", found = TRUE) %>%
+      left_join_all(mod_info, by = "mod_tags")
   }else{
     tag_levels <- unique(.tags) # message in order of tags
-    tag_groups <- crossing(mod_tags = mod_info$mod_tags, .tags) %>% left_join(mod_info, by = "mod_tags") %>%
+    tag_groups <- crossing(mod_tags = mod_info$mod_tags, .tags) %>%
+      left_join_all(mod_info, by = "mod_tags") %>%
       mutate(.tags = ordered(.tags, levels = tag_levels)) %>% arrange(.tags)
     found <- map2(tag_groups$mod_tags, tag_groups$.tags, function(tag.x, .tag){
       grepl(.tag, tag.x)


### PR DESCRIPTION
With the latest dplyr release, our test suite triggers a good number of warnings.  This PR resolves them.


`devtools::test()` result summary **before** this PR:

```
[ FAIL 0 | WARN 17 | SKIP 0 | PASS 1115 ]
```

`devtools::test()` result summary **after** this PR:


```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 1115 ]
```

---

@barrettk there's no rush on this (just would be good to get in before the next release), but I'd especially appreciate your input on the `delete_models` change.  I pretty sure multiple matches are expected, but I was getting turned around when trying to follow the code (in particular I was confused by the pasting of tags).