### PR TITLE
use_bbi fixes

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,4 +1,5 @@
-BBI_DEFAULT_PATH <- if (.Platform$OS.type == "windows") {
+ON_WINDOWS <- identical(.Platform$OS.type, "windows")
+BBI_DEFAULT_PATH <- if (ON_WINDOWS) {
   "bbi.exe"
 } else {
   "bbi"

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -341,9 +341,18 @@ version_message <- function(local_v, current_v){
                  .trim = FALSE))
 }
 
-try_path_real <- function(...) {
-  tryCatch(fs::path_real(...),
-           ENOENT = function(e) NULL)
+if (utils::packageVersion("fs") < "1.4.2") {
+  try_path_real <- function(path) {
+    if (!all(fs::file_exists(path))) {
+      return(NULL)
+    }
+    fs::path_real(path)
+  }
+} else {
+  try_path_real <- function(path) {
+    tryCatch(fs::path_real(path),
+             ENOENT = function(e) NULL)
+  }
 }
 
 #' Helper to message user about adding the bbi directory to $PATH

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -149,6 +149,7 @@ install_menu <- function(.path, .version, .force, .quiet){
 
   current_bbi_url <- current_release_url(owner = 'metrumresearchgroup', repo = 'bbi')
   current_v <- bbi_current_release(current_bbi_url)
+  aborted <- FALSE
 
   if (.version == 'latest') {
     .bbi_url <- current_bbi_url
@@ -170,6 +171,8 @@ install_menu <- function(.path, .version, .force, .quiet){
 
       if(utils::menu(choices = c('Yes','No'))==1){
         download_bbi(.bbi_url, .dest_bbi_path)
+      } else {
+        aborted <- TRUE
       }
     } else {
       download_bbi(.bbi_url, .dest_bbi_path)
@@ -177,8 +180,12 @@ install_menu <- function(.path, .version, .force, .quiet){
     local_v <- bbi_version(.dest_bbi_path)
   }
 
-  add_to_path_message(.dest_bbi_path)
-  if (!isTRUE(.quiet)) version_message(local_v = local_v, current_v = current_v)
+  if (!aborted) {
+    add_to_path_message(.dest_bbi_path)
+    if (!isTRUE(.quiet)) {
+      version_message(local_v = local_v, current_v = current_v)
+    }
+  }
 }
 
 

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -341,6 +341,11 @@ version_message <- function(local_v, current_v){
   cat(glue::glue(cli::col_blue(' - Current release: {current_v}\n')))
 }
 
+try_path_real <- function(...) {
+  tryCatch(fs::path_real(...),
+           ENOENT = function(e) NULL)
+}
+
 #' Helper to message user about adding the bbi directory to $PATH
 #'
 #' Will return invisibly if .bbi_path is the same as `getOption('bbr.bbi_exe_path')`
@@ -349,7 +354,13 @@ version_message <- function(local_v, current_v){
 #' @importFrom cli cli_alert
 #' @keywords internal
 add_to_path_message <- function(.bbi_path) {
-  if (.bbi_path == getOption('bbr.bbi_exe_path')) {
+  resolved_bbi_path <- try_path_real(.bbi_path)
+  if (is.null(resolved_bbi_path)) {
+    stop("Downloaded bbi unexpectedly does not exist at ",
+         .bbi_path)
+  }
+  if (identical(resolved_bbi_path,
+                try_path_real(getOption("bbr.bbi_exe_path")))) {
     return(invisible(NULL))
   }
 

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -35,10 +35,10 @@
 #' @importFrom glue glue_collapse
 #' @importFrom cli rule
 #'
-#' @param .path absolute path to install bbi to. See Details section for
-#'   defaults, if nothing is passed. Note that this should be the path where you
-#'   would like the bbi executable to be installed, _not_ the path to the
-#'   directory in which you want to install it. For example, you should pass
+#' @param .path path to install bbi to. See Details section for defaults, if
+#'   nothing is passed. Note that this should be the path where you would like
+#'   the bbi executable to be installed, _not_ the path to the directory in
+#'   which you want to install it. For example, you should pass
 #'   `"/some/dir/bbi"` and _not_ `"/some/dir"`.
 #' @param .version version of bbi to install. Must pass a character scalar
 #'   corresponding to a tag found in
@@ -143,8 +143,7 @@ bbi_current_release <- function(.bbi_url = NULL){
 #' @inheritParams use_bbi
 #' @keywords internal
 install_menu <- function(.path, .version, .force, .quiet){
-
-  .dest_bbi_path <- normalizePath(.path, mustWork = FALSE)
+  .dest_bbi_path <- fs::path_abs(.path)
   local_v <- bbi_version(.dest_bbi_path)
 
   current_bbi_url <- current_release_url(owner = 'metrumresearchgroup', repo = 'bbi')

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -78,6 +78,10 @@ use_bbi <- function(.path = NULL, .version = "latest", .force = FALSE, .quiet = 
     stop(err_msg)
   }
 
+  if (ON_WINDOWS && !identical(fs::path_ext(.path), "exe")) {
+    stop("Path must end with '.exe' on Windows. Got ", .path)
+  }
+
   dir_create(dirname(.path))
 
   on.exit(install_menu(.path, .version, .force, .quiet), add = TRUE)

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -222,11 +222,7 @@ build_bbi_install_path <- function() {
       if (home_dir == "") dev_error("build_bbi_install_path() can't find $HOME")
       file.path(home_dir, ".local", "share", "bbi", "bbi")
     },
-    "darwin" = {
-      home_dir <- Sys.getenv("HOME")
-      if (home_dir == "") dev_error("build_bbi_install_path() can't find $HOME")
-      "/usr/local/bin/bbi"
-    },
+    "darwin" = "/usr/local/bin/bbi",
     "windows" = {
       app_dir <- Sys.getenv("APPDATA")
       if (app_dir == "") dev_error("build_bbi_install_path() can't find $APPDATA")

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -337,7 +337,8 @@ version_message <- function(local_v, current_v){
     }
   }
 
-  cat(glue::glue(cli::col_blue(' - Current release: {current_v}\n')))
+  cat(glue::glue(cli::col_blue(' - Current release: {current_v}\n'),
+                 .trim = FALSE))
 }
 
 try_path_real <- function(...) {

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -230,7 +230,7 @@ build_bbi_install_path <- function() {
     "windows" = {
       app_dir <- Sys.getenv("APPDATA")
       if (app_dir == "") dev_error("build_bbi_install_path() can't find $APPDATA")
-      file.path(app_dir, "bbi", "bbi")
+      file.path(app_dir, "bbi", "bbi.exe")
     },
     {
       dev_error(glue("build_bbi_install_path() got invalid operating system: {os}"))

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -363,19 +363,8 @@ add_to_path_message <- function(.bbi_path) {
                 try_path_real(getOption("bbr.bbi_exe_path")))) {
     return(invisible(NULL))
   }
-
-  old_path <- Sys.getenv("PATH")
-
-  if (check_os() == "windows") {
-    .sep = ";"
-  } else {
-    .sep = ":"
-  }
-
-  old_path_dirs <- unlist(str_split(old_path, .sep))
-
-  new_dir <- dirname(.bbi_path)
-  if (new_dir %in% old_path_dirs) {
+  if (identical(try_path_real(Sys.which(basename(.bbi_path))),
+                resolved_bbi_path)) {
     return(invisible(NULL))
   }
 

--- a/R/use-bbi.R
+++ b/R/use-bbi.R
@@ -368,7 +368,13 @@ add_to_path_message <- function(.bbi_path) {
     return(invisible(NULL))
   }
 
-  cli::cli_alert(glue("Please either set `options('bbr.bbi_exe_path' = '{.bbi_path}')` in your .Rprofile, or add this location to $PATH in your .bash_profile"))
+  parent_dir <- fs::path_dir(.bbi_path)
+  path <- deparse(as.character(.bbi_path))
+  cli::cli_alert(
+    c("Please either set\n\n",
+      "  options(bbr.bbi_exe_path = {path})\n\n",
+      "in your .Rprofile, or put {parent_dir}\n",
+      "at the front of your environment's `PATH`"))
 }
 
 

--- a/inst/validation/bbr-requirements.yaml
+++ b/inst/validation/bbr-requirements.yaml
@@ -1031,6 +1031,10 @@ UBI-R006:
   tests:
   - BBR-UBI-002
   - BBR-UBI-006
+UBI-R007:
+  description: use_bbi reports if additional setup is required
+  tests:
+  - BBR-UBI-007
 UTL-R001:
   description: wait_for_nonmem() correctly reads in stop time
   tests:

--- a/inst/validation/bbr-stories.yaml
+++ b/inst/validation/bbr-stories.yaml
@@ -44,6 +44,7 @@ CFG-S004:
   - UBI-R004
   - UBI-R005
   - UBI-R006
+  - UBI-R007
   - RBP-R001
 CFG-S005:
   name: Pass .bbi_args to bbi_init()

--- a/man/install_menu.Rd
+++ b/man/install_menu.Rd
@@ -7,10 +7,10 @@
 install_menu(.path, .version, .force, .quiet)
 }
 \arguments{
-\item{.path}{absolute path to install bbi to. See Details section for
-defaults, if nothing is passed. Note that this should be the path where you
-would like the bbi executable to be installed, \emph{not} the path to the
-directory in which you want to install it. For example, you should pass
+\item{.path}{path to install bbi to. See Details section for defaults, if
+nothing is passed. Note that this should be the path where you would like
+the bbi executable to be installed, \emph{not} the path to the directory in
+which you want to install it. For example, you should pass
 \code{"/some/dir/bbi"} and \emph{not} \code{"/some/dir"}.}
 
 \item{.version}{version of bbi to install. Must pass a character scalar

--- a/man/use_bbi.Rd
+++ b/man/use_bbi.Rd
@@ -7,10 +7,10 @@
 use_bbi(.path = NULL, .version = "latest", .force = FALSE, .quiet = NULL)
 }
 \arguments{
-\item{.path}{absolute path to install bbi to. See Details section for
-defaults, if nothing is passed. Note that this should be the path where you
-would like the bbi executable to be installed, \emph{not} the path to the
-directory in which you want to install it. For example, you should pass
+\item{.path}{path to install bbi to. See Details section for defaults, if
+nothing is passed. Note that this should be the path where you would like
+the bbi executable to be installed, \emph{not} the path to the directory in
+which you want to install it. For example, you should pass
 \code{"/some/dir/bbi"} and \emph{not} \code{"/some/dir"}.}
 
 \item{.version}{version of bbi to install. Must pass a character scalar

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -31,6 +31,12 @@ test_that("use-bbi works on linux with path specified [BBR-UBI-002]", {
   use_bbi(.path = bbi_tmp_path, .force = TRUE)
   f_info <- file.info(bbi_tmp_path)
   expect_equal(as.character(f_info$mode), '755')
+
+  withr::with_tempdir({
+    relpath <- file.path("bin", "bbi")
+    use_bbi(.path = relpath, .force = TRUE)
+    checkmate::expect_file_exists(relpath, access = "x")
+  })
 })
 
 

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -104,6 +104,14 @@ test_that("add_to_path_message() reports needed setup [BBR-UBI-007]", {
       withr::with_envvar(new = c("PATH" = paste0(getwd(), ":")),
                          action = "prefix",
                          expect_silent(add_to_path_message(path)))
+      # Target path is in PATH but shadowed.
+      fs::dir_create("sub")
+      fs::file_copy(path, file.path("sub", "bbi"))
+      newpath <- paste0(fs::path_abs("sub"), ":", Sys.getenv("PATH"),
+                        ":", getwd())
+      withr::with_envvar(new = c("PATH" = newpath), action = "replace",
+                         expect_message(add_to_path_message(path),
+                                        "Please either set"))
     })
   })
 })

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -81,3 +81,24 @@ test_that("use_bbi errors when passed a directory [BBR-UBI-006]", {
     expect_error(use_bbi(.path = REF_DIR), regexp = "bbi_exe_path")
   )
 })
+
+test_that("add_to_path_message() reports needed setup [BBR-UBI-007]", {
+  withr::with_tempdir({
+    fs::file_touch("bbi")
+    fs::file_chmod("bbi", mode = "755")
+    path <- fs::path_abs("bbi")
+
+    # Target path in effect via option.
+    withr::with_options(
+      list(bbr.bbi_exe_path = path),
+      expect_silent(add_to_path_message(path)))
+    withr::with_options(list(bbr.bbi_exe_path = "foo"), {
+      # Target path not in effect via option or PATH.
+      expect_message(add_to_path_message(path), "Please either set")
+      # Target path in effect via PATH.
+      withr::with_envvar(new = c("PATH" = paste0(getwd(), ":")),
+                         action = "prefix",
+                         expect_silent(add_to_path_message(path)))
+    })
+  })
+})

--- a/tests/testthat/test-use-bbi.R
+++ b/tests/testthat/test-use-bbi.R
@@ -83,6 +83,8 @@ test_that("use_bbi errors when passed a directory [BBR-UBI-006]", {
 })
 
 test_that("add_to_path_message() reports needed setup [BBR-UBI-007]", {
+  expect_error(add_to_path_message("idontexist"),
+               "unexpectedly does not exist")
   withr::with_tempdir({
     fs::file_touch("bbi")
     fs::file_chmod("bbi", mode = "755")
@@ -91,6 +93,9 @@ test_that("add_to_path_message() reports needed setup [BBR-UBI-007]", {
     # Target path in effect via option.
     withr::with_options(
       list(bbr.bbi_exe_path = path),
+      expect_silent(add_to_path_message(path)))
+    withr::with_options(
+      list(bbr.bbi_exe_path = "./bbi"),
       expect_silent(add_to_path_message(path)))
     withr::with_options(list(bbr.bbi_exe_path = "foo"), {
       # Target path not in effect via option or PATH.


### PR DESCRIPTION
This series fixes a few `use_bbi` issues.  These were prompted/surfaced by Windows testing (see gh-576), but most of these are also problems outside of Windows.

Main issues fixed:

 - "set bbr.bbi_exe_path or add to PATH" message was shown even if caller aborted

 - "set bbr.bbi_exe_path or add to PATH" message misfired on valid `bbr.bbi_exe_path` if it didn't exactly match the `normalizePath()` output

 - "set bbr.bbi_exe_path or add to PATH" did _not_ fire if the paths directory was in `PATH` but overshadowed

 - relative path like `use_bbi("bin/bbi")` triggered a dev error

 - ensure target path on Windows ends with ".exe"

Closes #576

(I'll have one followup PR that uses this as a base. edit: that's gh-581)

---

todo:

- [x] final round of interactive testing on windows
- [x] adjust for compatibility with mpn oldest ([failing build](https://github-drone.metrumrg.com/metrumresearchgroup/bbr/3432/2/1))
