### PR TITLE
set bbr.bbi_exe_mode default to 'local' unless on linux

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -4,7 +4,6 @@ BBI_DEFAULT_PATH <- if (.Platform$OS.type == "windows") {
   "bbi"
 }
 
-BBI_DEFAULT_MODE <- "sge"
 BBI_VALID_MODES <- c("local", "sge")
 
 CACHE_ENV <- new.env(parent = emptyenv())

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,7 +12,11 @@
   }
 
   if (is.null(getOption("bbr.bbi_exe_mode"))) {
-    options("bbr.bbi_exe_mode" = BBI_DEFAULT_MODE)
+    if (identical(check_os(), "linux")) {
+      options("bbr.bbi_exe_mode" = "sge")
+    } else {
+      options("bbr.bbi_exe_mode" = "local")
+    }
   }
 
   # set bbi minimum version


### PR DESCRIPTION
"local" is likely the better default for a user on Windows or macOS (though based on light searching, it may be possible to install SGE on Windows and macOS).