### PR TITLE
check_bbi_exe: warn on Windows unless bbi is at least v3.2.2

### DIFF
--- a/R/bbr.R
+++ b/R/bbr.R
@@ -187,6 +187,11 @@ check_bbi_exe <- function(.bbi_exe_path) {
 
     # if version too low, reject it
     assert_bbi_version(.bbi_exe_path)
+    if (ON_WINDOWS && !test_bbi_version(.min_version = "3.2.2")) {
+      warning("Your version of bbi is ", bbi_version(), ".\n",
+              "Please update to v3.2.2 or later to fix several known issues.\n",
+              "Install latest version with `bbr::use_bbi()`.")
+    }
 
     # if found, and passes version constraint, add it to cache
     CACHE_ENV$bbi_exe_paths[[.bbi_exe_path]] <- TRUE


### PR DESCRIPTION
bbi 3.2.2 has Windows fixes for `bbi init` and `bbi nonmem run`. Without these, submitting a model is unlikely to be successful, but still warn rather than error because 1) there may be some configurations/setups where a previous version would work and 2) older bbi versions should work for older commands like `bbi nonmem summary` that don't depend on running NONMEM.

---

Merging should wait until:

- [x] base has been merged (#579)
- [x] bbi 3.2.2 has been released