### PR TITLE
DESCRIPTION: add pkgdown site to URL field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Description: R package for making calls to bbi for running
     NONMEM and other models. Also manages model metadata, workflow, and
     run logs.
 License: MIT + file LICENSE
-URL: https://github.com/metrumresearchgroup/bbr
+URL: https://metrumresearchgroup.github.io/bbr, https://github.com/metrumresearchgroup/bbr
 BugReports: https://github.com/metrumresearchgroup/bbr/issues
 Depends:
     R (>= 3.5)


### PR DESCRIPTION
The pkgdown site needs to be listed in the DESCRIPTION's URL field in order for pkgdown to auto-link to bbr pages when building another package's site.

https://pkgdown.r-lib.org/articles/linking.html#across-packages

---

With the bbr.bayes pkgdown site, I've confirmed that this change is sufficient to get things like "\`new_model()\`" to auto-link to <https://metrumresearchgroup.github.io/bbr/reference/new_model.html> instead of the fallback target of <https://rdrr.io/pkg/bbr/man/new_model.html>.