### PR TITLE
README: adjust cheat sheet thumbnail height

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ There are several other vignettes, and more are being added as new functionality
 
 ### Cheat Sheet
 
-<a href="https://metrumresearchgroup.github.io/cheatsheets/bbr_nonmem_cheat_sheet.pdf"><img src="https://metrumresearchgroup.github.io/cheatsheets/thumbnails/bbr_nonmem_cheat_sheet_thumbnail.png" width="700" height="265"/></a> 
+<a href="https://metrumresearchgroup.github.io/cheatsheets/bbr_nonmem_cheat_sheet.pdf"><img src="https://metrumresearchgroup.github.io/cheatsheets/thumbnails/bbr_nonmem_cheat_sheet_thumbnail.png" width="700" height="395"/></a> 
 
 ### Featured Vignettes
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ functionality is rolled out. A complete list can be found
 
 ### Cheat Sheet
 
-<a href="https://metrumresearchgroup.github.io/cheatsheets/bbr_nonmem_cheat_sheet.pdf"><img src="https://metrumresearchgroup.github.io/cheatsheets/thumbnails/bbr_nonmem_cheat_sheet_thumbnail.png" width="700" height="265"/></a>
+<a href="https://metrumresearchgroup.github.io/cheatsheets/bbr_nonmem_cheat_sheet.pdf"><img src="https://metrumresearchgroup.github.io/cheatsheets/thumbnails/bbr_nonmem_cheat_sheet_thumbnail.png" width="700" height="395"/></a>
 
 ### Featured Vignettes
 


### PR DESCRIPTION
There's a new cheat sheet up with a different aspect ratio.  Adjust the height so that the w/h ratio is close to the png's:

    $ file bbr_nonmem_cheat_sheet_thumbnail.png
    bbr_nonmem_cheat_sheet_thumbnail.png: PNG image data, 1000 x 563, 8-bit/color RGB, non-interlaced