### PR TITLE
update_model_id: use nmrec for updating the table files

### DIFF
--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -80,21 +80,25 @@ update_model_id <- function(
     paste(collapse = "|") %>%
     paste0("(", ., ")\\b")
 
-  ## edit text of new model file
-  txt <- suppressSpecificWarning(
-    read_lines(modelfile),
-    .regexpr = "incomplete final line"
-  )
+  ## parse table records
+  mod_str <- nmrec::read_ctl(modelfile)
+  table_recs <- nmrec::select_records(mod_str, "table")
 
-  txt <- gsub(
-    paste0(based_on, .suffixes),
-    paste0(mod_id, "\\1"),
-    txt,
-    ignore.case = TRUE
-  )
+  ## edit records with new model file
+  purrr::walk(table_recs, function(tbl_rec){
+    tbl_file <- nmrec::get_record_option(tbl_rec, "file")
+    txt <- gsub(
+      paste0(based_on, .suffixes),
+      paste0(mod_id, "\\1"),
+      tbl_file$value,
+      ignore.case = TRUE
+    )
+    tbl_file$value <- txt
+  })
+
 
   ## write updated model file
-  write_lines(txt, modelfile)
+  nmrec::write_ctl(mod_str, modelfile)
 
   ## return model to make this a pipeable function
   return(invisible(.mod))

--- a/tests/testthat/test-copy-model-helpers.R
+++ b/tests/testthat/test-copy-model-helpers.R
@@ -7,19 +7,59 @@ DEFAULT_SUFFIXES <- c(
   'par.tab'
 )
 
+set_table_files <- function(.mod, mod_id, suffixes = DEFAULT_SUFFIXES){
+  mod_str <- nmrec::read_ctl(get_model_path(.mod))
+
+  # Replace table records with repeated identical record; length of `suffixes`
+  is_table <- purrr::map_lgl(mod_str$records, function(r) r$name == "table")
+  if (any(is_table)) {
+    new_recs <- purrr::map(seq_along(suffixes), ~{
+      mod_str$records[is_table][[1]]
+    })
+    mod_str$records[is_table] <- NULL
+
+    mod_str$records <- c(mod_str$records, new_recs)
+    # save out ctl to recalibrate records
+    nmrec::write_ctl(mod_str, get_model_path(.mod))
+  }
+
+  # set all table records to cover all of suffixes
+  mod_str <- nmrec::read_ctl(get_model_path(.mod))
+  table_recs <- nmrec::select_records(mod_str, "table")
+  purrr::walk2(table_recs, suffixes,
+               function(tbl_rec, suffix){
+                 table_file <- nmrec::get_record_option(tbl_rec, "file")
+                 table_file$value <- paste0(mod_id, suffix)
+               })
+  nmrec::write_ctl(mod_str, get_model_path(.mod))
+}
+
+
+get_table_files <- function(.mod){
+  mod_str <- nmrec::read_ctl(get_model_path(.mod))
+  table_recs <- nmrec::select_records(mod_str, "table")
+
+  table_files <- purrr::map_chr(table_recs, function(tbl_rec){
+    nmrec::get_record_option(tbl_rec, "file")$value
+  })
+
+  return(table_files)
+}
+
 test_that("update_model_id() works with run number [BBR-CMH-001]", {
   on.exit({ cleanup() })
 
   # copy model and write strings with parent id to control stream
   new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
-  readr::write_lines(
-    paste0(get_model_id(MOD1), DEFAULT_SUFFIXES),
-    get_model_path(new_mod)
-  )
 
+  # overwrite starting table files
+  set_table_files(new_mod, mod_id = get_model_id(MOD1))
+
+  # update model id
   update_model_id(new_mod)
+
   expect_equal(
-    readr::read_lines(get_model_path(new_mod)),
+    get_table_files(new_mod),
     paste0(get_model_id(new_mod), DEFAULT_SUFFIXES)
   )
 })
@@ -30,14 +70,15 @@ test_that("update_model_id() works with character ID [BBR-CMH-002]", {
   # copy model and write strings with parent id to control stream
   parent_mod <- copy_model_from(MOD1, "Parent")
   new_mod <- copy_model_from(parent_mod, "Child")
-  readr::write_lines(
-    paste0(get_model_id(parent_mod), DEFAULT_SUFFIXES),
-    get_model_path(new_mod)
-  )
 
+  # overwrite starting table files
+  set_table_files(new_mod, mod_id = get_model_id(parent_mod))
+
+  # update model id
   update_model_id(new_mod)
+
   expect_equal(
-    readr::read_lines(get_model_path(new_mod)),
+    get_table_files(new_mod),
     paste0(get_model_id(new_mod), DEFAULT_SUFFIXES)
   )
 })
@@ -48,14 +89,15 @@ test_that("update_model_id() is case-sensitive [BBR-CMH-003]", {
 
   # copy model and write strings with parent id to control stream
   new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
-  readr::write_lines(
-    paste0(get_model_id(MOD1), suff_all_case),
-    get_model_path(new_mod)
-  )
 
+  # overwrite starting table files
+  set_table_files(new_mod, mod_id = get_model_id(MOD1), suffixes = suff_all_case)
+
+  # update model id
   update_model_id(new_mod)
+
   expect_equal(
-    readr::read_lines(get_model_path(new_mod)),
+    get_table_files(new_mod),
     paste0(get_model_id(new_mod), suff_all_case)
   )
 })
@@ -67,14 +109,14 @@ test_that("update_model_id() .suffixes works [BBR-CMH-004]", {
   new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
   orig_suff <- paste0(get_model_id(MOD1), DEFAULT_SUFFIXES)
 
-  readr::write_lines(
-    orig_suff,
-    get_model_path(new_mod)
-  )
+  # overwrite starting table files
+  set_table_files(new_mod, mod_id = get_model_id(MOD1))
 
+  # update model id
   update_model_id(new_mod, .suffixes = DEFAULT_SUFFIXES[1])
+
   expect_equal(
-    readr::read_lines(get_model_path(new_mod)),
+    get_table_files(new_mod),
     c(
       paste0(get_model_id(new_mod), DEFAULT_SUFFIXES[1]),
       orig_suff[2:length(orig_suff)]
@@ -90,14 +132,14 @@ test_that("update_model_id() .additional_suffixes works [BBR-CMH-005]", {
   new_mod <- copy_model_from(MOD1, basename(NEW_MOD2))
   new_suff <- ".naw"
 
-  readr::write_lines(
-    paste0(get_model_id(MOD1), c(DEFAULT_SUFFIXES, new_suff)),
-    get_model_path(new_mod)
-  )
+  # overwrite starting table files
+  set_table_files(new_mod, mod_id = get_model_id(MOD1),
+                  suffixes = c(DEFAULT_SUFFIXES, new_suff))
 
   update_model_id(new_mod, .additional_suffixes = new_suff)
+
   expect_equal(
-    readr::read_lines(get_model_path(new_mod)),
+    get_table_files(new_mod),
     paste0(get_model_id(new_mod), c(DEFAULT_SUFFIXES, new_suff))
   )
 })


### PR DESCRIPTION
 - still uses the old regex. Dont see a way to avoid this
 - tests updates. It is now insufficient to just write suffixes to the file, as `nmrec` must be able to parse individual records
    - added two helper functions in this file for A) setting the default table files, and B) getting the table records

addresses `update_model_id()` part of https://github.com/metrumresearchgroup/bbr/issues/599