### PR TITLE
pkgr.yml: update MPN date

### DIFF
--- a/pkgr.yml
+++ b/pkgr.yml
@@ -9,7 +9,7 @@ Packages:
 
 Repos:
   - CRAN: https://cran.rstudio.com
-  - MPN: https://mpn.metworx.com/snapshots/stable/2022-06-15 # used for mrgval
+  - MPN: https://mpn.metworx.com/snapshots/stable/2023-09-19 # used for mrgval
 
 Lockfile:
   Type: renv


### PR DESCRIPTION
This brings over the @barrettk's initial commit from gh-610, which updates the MPN snapshot to one with nmrec.  As discussed [here](https://github.com/metrumresearchgroup/bbr/commit/dac03d29490d9f907aeaeb067dbe2072f5ec9cd9#commitcomment-131008690), not doing so in gh-606 was an oversight, and it'd be good to get that into main without tying it up to an unrelated PR.

An additional reason for pulling it out is that it'll let us see whether Drone is still misbehaving: https://github.com/metrumresearchgroup/bbr/pull/606#issuecomment-1756226915