### PR TITLE
update_model_id: work with child models in sub-directories

### DIFF
--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -65,11 +65,13 @@ update_model_id <- function(
   check_yaml_in_sync(.mod)
   mod_id <- get_model_id(.mod)
   modelfile <- get_model_path(.mod)
-  based_on <- .mod$based_on[1]
+  based_on <- get_based_on(.mod)
   if (is.null(based_on)) {
     stop(glue("Cannot call update_model_id() because .mod$based_on is empty for model {mod_id}"))
+  }else{
+    based_on_id <- get_model_id(based_on)
   }
-  message(glue("replacing {based_on} with {mod_id} in {modelfile}"))
+  message(glue("replacing {based_on_id} with {mod_id} in {modelfile}"))
 
   ## construct suffixes regex string
   assert_character(.suffixes)
@@ -87,7 +89,7 @@ update_model_id <- function(
   )
 
   txt <- gsub(
-    paste0(based_on, .suffixes),
+    paste0(based_on_id, .suffixes),
     paste0(mod_id, "\\1"),
     txt,
     ignore.case = TRUE

--- a/R/copy-model-helpers.R
+++ b/R/copy-model-helpers.R
@@ -66,6 +66,7 @@ update_model_id <- function(
   mod_id <- get_model_id(.mod)
   modelfile <- get_model_path(.mod)
   based_on <- get_based_on(.mod)
+
   if (is.null(based_on)) {
     stop(glue("Cannot call update_model_id() because .mod$based_on is empty for model {mod_id}"))
   }else{
@@ -89,7 +90,7 @@ update_model_id <- function(
   )
 
   txt <- gsub(
-    paste0(based_on_id, .suffixes),
+    paste0("\\Q",based_on_id,"\\E", .suffixes),
     paste0(mod_id, "\\1"),
     txt,
     ignore.case = TRUE

--- a/tests/testthat/test-copy-model-helpers.R
+++ b/tests/testthat/test-copy-model-helpers.R
@@ -108,3 +108,30 @@ test_that("update_model_id() errors with no based_on [BBR-CMH-006]", {
     regexp = "based_on is empty"
   )
 })
+
+
+test_that("update_model_id() works with models in different directories", {
+
+  # create to child directory
+  child_dir <- file.path(MODEL_DIR, "child_dir")
+  fs::dir_create(child_dir)
+  on.exit(fs::dir_delete(child_dir), add = TRUE)
+
+  # copy model and write strings with parent id to control stream
+  new_mod <- copy_model_from(
+    MOD1,
+    file.path(basename(child_dir), basename(NEW_MOD2))
+  )
+  new_suff <- "-1.msf"
+
+  readr::write_lines(
+    paste0(get_model_id(MOD1), c(DEFAULT_SUFFIXES, new_suff)),
+    get_model_path(new_mod)
+  )
+
+  update_model_id(new_mod, .additional_suffixes = new_suff)
+  expect_equal(
+    readr::read_lines(get_model_path(new_mod)),
+    paste0(get_model_id(new_mod), c(DEFAULT_SUFFIXES, new_suff))
+  )
+})

--- a/tests/testthat/test-copy-model-helpers.R
+++ b/tests/testthat/test-copy-model-helpers.R
@@ -135,3 +135,20 @@ test_that("update_model_id() works with models in different directories", {
     paste0(get_model_id(new_mod), c(DEFAULT_SUFFIXES, new_suff))
   )
 })
+
+
+test_that("update_model_id() protects regex characters in parent model ID", {
+  withr::with_tempdir({
+    mod1a <- copy_model_from(MOD1, file.path(getwd(), "1+"))
+    mod2 <- copy_model_from(mod1a, 2)
+
+    mod2_path <- get_model_path(mod2)
+    readr::write_lines(c("1+.tab", "11.tab"), mod2_path)
+
+    update_model_id(mod2)
+    expect_identical(
+      readr::read_lines(mod2_path),
+      c("2.tab", "11.tab")
+    )
+  })
+})


### PR DESCRIPTION
Previously, `update_model_id` would replace the id with the `based_on` field, which was actually a relative path rather than a model id. In other words, this function did not support child models created in sub-directories (or otherwise a different directory than the parent model). This PR addresses that by capturing the id of the parent model instead of the path. See referenced issue for more details.


closes https://github.com/metrumresearchgroup/bbr/issues/611