### PR TITLE
nm_join: record source of columns in attribute

### DIFF
--- a/R/nm-join.R
+++ b/R/nm-join.R
@@ -62,6 +62,10 @@
 #' data will be renamed to `DV.DATA` and the column from the table file kept as
 #' `DV`.
 #'
+#' The origin of each column is attached to the return value via the
+#' "nm_join_origin" attribute, a list that maps each source (as named by
+#' [nm_tables()]) to the columns that came from that source.
+#'
 #' **Duplicate Rows Warning for Join Column**
 #'
 #' If there are duplicate rows found in the specified `.join_col`, a warning will be raised specifying a subset of the repeated rows.
@@ -109,6 +113,11 @@ nm_join <- function(
     .d <- rename(.d, DV.DATA = "DV")
   }
   col_order <- names(.d)
+
+  # Keep track of where each column came from.
+  origin <- vector(mode = "list", length = length(df_list))
+  names(origin) <- names(df_list)
+  origin$data <- col_order
 
   .join_col <- toupper(.join_col)
   if (!(.join_col %in% names(.d))) {
@@ -173,6 +182,7 @@ nm_join <- function(
       col_order <- union(col_order, names(tab))
       .d <- join_fun(tab, .d, by = .join_col)
     }
+    origin[[.n]] <- names(tab)
   }
 
   verbose_msg(c(
@@ -181,7 +191,10 @@ nm_join <- function(
     glue("  cols: {ncol(.d)}")
   ))
 
-  return(select(.d, !!col_order))
+  res <- select(.d, !!col_order)
+  attr(res, "nm_join_origin") <- origin
+
+  return(res)
 }
 
 

--- a/man/nm_join.Rd
+++ b/man/nm_join.Rd
@@ -82,6 +82,10 @@ data \emph{and} at least one of the table files, the \code{DV} column from the i
 data will be renamed to \code{DV.DATA} and the column from the table file kept as
 \code{DV}.
 
+The origin of each column is attached to the return value via the
+"nm_join_origin" attribute, a list that maps each source (as named by
+\code{\link[=nm_tables]{nm_tables()}}) to the columns that came from that source.
+
 \strong{Duplicate Rows Warning for Join Column}
 
 If there are duplicate rows found in the specified \code{.join_col}, a warning will be raised specifying a subset of the repeated rows.

--- a/tests/testthat/test-nm-join.R
+++ b/tests/testthat/test-nm-join.R
@@ -104,6 +104,21 @@ test_that("nm_join() works correctly with duplicate cols [BBR-NMJ-004]", {
   expect_equal(test_df$DV.DATA, test_df$DV)
 })
 
+test_that("nm_join() records origin of columns in attribute", {
+  res <- nm_join(MOD1, .files = c("1.tab", "1par.tab", "1dups.tab"))
+  origin <- attr(res, "nm_join_origin")
+  sources <- c("data", "tab", "par.tab", "dups.tab")
+  for (source in sources) {
+    expect_true("NUM" %in% origin[[source]])
+  }
+
+  data <- nm_data(MOD1)
+  expect_identical(setdiff(origin[["data"]], names(data)), "DV.DATA")
+
+  expect_identical(origin[["par.tab"]], c("NUM", "CL", "V", "KA", "ETA1", "ETA2"))
+  expect_identical(origin[["dups.tab"]], c("NUM", "FAKE"))
+})
+
 test_that("nm_join(.join_col) works correctly with duplicate cols  [BBR-NMJ-005]", {
   # this test is annoyingly complex to set up because of the
   # mechanics of how the data is pulled and the internal checks


### PR DESCRIPTION
The upcoming nm_join_bayes() function in bbr.bayes, which uses nm_join() underneath, needs to know which columns in the result came from the data file and which came from tables.  bbr.bayes can repeat some of the same logic to figure that out (and already has a compatibility fallback), but it'd be more reliable and future-proof if nm_join() provided that information.

Update nm_join() to track the origin of each column and store that map as an attribute of the return value.

Instead of using an attribute, we could avoid exposing this information to other callers by adding an internal layer to nm_join() for bbr.bayes to use.  However, an attribute is fairly tucked away, it seems likely that some other caller may find this information useful, and it's not much for nm_join() to commit to compatibility-wise.

Re: https://github.com/metrumresearchgroup/bbr.bayes/pull/106