### PR TITLE
drone: update to latest bbi

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
   commands:
   - chmod +x install_bbi.sh
-  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.2.2'
+  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.3.0'
   volumes:
   - name: cache
     path: /ephemeral
@@ -148,7 +148,7 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cran-latest
   commands:
   - chmod +x install_bbi.sh
-  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.2.2'
+  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.3.0'
   volumes:
   - name: cache
     path: /ephemeral
@@ -218,7 +218,7 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
   commands:
   - chmod +x install_bbi.sh
-  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.2.2'
+  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.3.0'
   volumes:
   - name: cache
     path: /ephemeral
@@ -277,7 +277,7 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:latest
   commands:
   - chmod +x install_bbi.sh
-  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.2.2'
+  - ./install_bbi.sh -p /ephemeral/bbi -v 'v3.3.0'
   volumes:
   - name: cache
     path: /ephemeral


### PR DESCRIPTION
Note that this leaves the "oldest" pipeline at v3.0.2, because that uses an old bbi intentionally.