### PR TITLE
tests: add missing skips for SUM1-based tests

### DIFF
--- a/tests/testthat/test-nm-file.R
+++ b/tests/testthat/test-nm-file.R
@@ -6,6 +6,7 @@ test_that("nm_file() works: model object [BBR-NMF-001]", {
 })
 
 test_that("nm_file() works: summary object [BBR-NMF-001]", {
+  skip_if_not_drone_or_metworx("nm_file() summary object")
   .d <- nm_file(SUM1, ".cov")
   expect_equal(ncol(.d), MOD1_PARAM_COUNT+1)
   expect_equal(nrow(.d), MOD1_PARAM_COUNT)

--- a/tests/testthat/test-nm-tables.R
+++ b/tests/testthat/test-nm-tables.R
@@ -10,6 +10,7 @@ test_that("nm_tables() works: model object [BBR-NMT-001]", {
 })
 
 test_that("nm_tables() works: summary object [BBR-NMT-001]", {
+  skip_if_not_drone_or_metworx("nm_tables() summary object")
   res <- nm_tables(SUM1, .files = TAB_FILE)
   expect_equal(length(res), 2)
   expect_equal(res$data, nm_data(MOD1))


### PR DESCRIPTION
When not running on Metworx or Drone, setup-workflow-ref.R doesn't define SUM1.  Most spots that use SUM1 call
skip_if_not_drone_or_metworx() to avoid an "object 'SUM1' not found" error.  Fix the two spots that don't.