### PR TITLE
bug fix: dont tabulate threads before deleting models.

### DIFF
--- a/R/test-threads.R
+++ b/R/test-threads.R
@@ -232,7 +232,6 @@ delete_models <- function(.mods, .tags = "test threads", .force = FALSE){
     mod_tags <- ifelse(mod_tags == "", "NA", mod_tags)
     tibble::tibble(
       mod_paths = mod.x$absolute_model_path,
-      mod_thread = mod.x$bbi_args$threads,
       mod_tags = mod_tags
     )
   })


### PR DESCRIPTION
 - This was never used. Perhaps it was for a message during development, but it has no use case within the function.
 - The bug only existed for R 4.0 using mpn-oldest. When `mod$bbi_args` was `NULL`, `tibble` would be unable to create a dataframe. This was first discovered when trying to delete the `example2_saemimp` model in the inherit-estimates PR (see [drone](https://github-drone.metrumrg.com/metrumresearchgroup/bbr/3658/2/4)):
 ```r
> test_check("bbr")
--
231 | ── 1. Error: inherit_param_estimates: integration: fails with old method of usin
232 | Internal error: Unexpected `NULL` in `vec_slice_impl()`.
233 | Backtrace:
234 | 1. bbr::delete_models(mod_est, .tags = NULL, .force = TRUE)
235 | 2. purrr::map_dfr(...)
236 | 3. dplyr::bind_rows(res, .id = .id)
237 | 4. vctrs::vec_rbind(!!!dots, .names_to = .id)
 ```

To reproduce this bug, you can run this test:
```
test_that("delete_models", {
  mod <- read_model(file.path(MODEL_DIR_X, "example2_saemimp"))
  mod_est <- copy_model_from(mod, "mod_est", "Inherit estimates", .overwrite = TRUE)
  delete_models(mod_est, .tags = NULL, .force = TRUE)
  expect_true(1==1)
})
```

`pkgr` file for reproducing this environment:
```
Version: 1
Descriptions:
  - DESCRIPTION

Packages:
  - devtools
  - pkgdown
  - styler

Repos:
  - MPN: https://mpn.metworx.com/snapshots/stable/2020-06-08

Lockfile:
  Type: renv

Rpath: ${R_EXE_4_0}
```