### PR TITLE
get_param: fix data length for constructed matrix

### DIFF
--- a/R/get-param.R
+++ b/R/get-param.R
@@ -127,7 +127,7 @@ format_matrix <- function(.values, .labels, .type = c("OMEGA", "SIGMA")){
   .cols <- map(matrix_pos, 2) %>% unlist() %>% as.numeric()
 
   # Assign values to corresponding location
-  .mat <- matrix(rep(0,max(.rows, .cols)*2), nrow = max(.rows), ncol = max(.cols))
+  .mat <- matrix(0, nrow = max(.rows), ncol = max(.cols))
   for(i in seq_along(.rows)){
     .mat[.rows[i],.cols[i]] <- .values[i]
     .mat[.cols[i],.rows[i]] <- .values[i]


### PR DESCRIPTION
When creating the matrix from a vector and labels, format_matrix() calculates the data size as 2 * N, where N is the maximum label index (e.g., 2 * 3 for a 3x3 matrix).  The correct size is N * N.

Fortunately that error doesn't functionally matter because matrix's ncol and nrow arguments, not the input data length, control the final shape.

R 4.2 or later flags the issue in cases where 2 * N isn't a multiple of N * N.  Several spots in test-get-param.R now trigger a warning: "data length differs from size of matrix".

Fix the issue by dropping the rep() call entirely and passing a scalar.  matrix() will repeat that as many times as needed.