### PR TITLE
Add more documentation to `bbi_init`: make `.nonmem_dir` argument more clear

### DIFF
--- a/R/bbr.R
+++ b/R/bbr.R
@@ -324,13 +324,32 @@ bbi_help <- function(.cmd_args=NULL) {
 #'  **Notes on `.nonmem_dir`**
 #'
 #'   `bbi` tries to detect subdirectories for different NONMEM versions, along
-#'   with a license file and executable within the subdirectory. `.nonmem_dir`
-#'   should therefore point to the *parent* directory containing the executable.
+#'   with a license file and executable within the subdirectory.
 #'
-#'   If your NONMEM executable exists in the the location `/opt/NONMEM/nm75/run`,
-#'   `.nonmem_dir` should point to `/opt/NONMEM/`, rather than the subdirectory
-#'   `/opt/NONMEM/nm75`. You would then denote the preferred NONMEM version by
-#'   specifying `.nonmem_version = 'nm75'`
+#'   `.nonmem_dir` should point to the **parent** directory that contains one
+#'   or more NONMEM installations.  It should *not* point to the installation
+#'   directory itself.  Here is an example:
+#'
+#' ```
+#'     /opt/NONMEM/
+#'     |-- nm74
+#'     |   |-- license
+#'     |   |-- run
+#'     |   |-- source
+#'     |   | ...
+#'     |   `-- util
+#'     `-- nm75
+#'         |-- license
+#'         |-- run
+#'         |-- source
+#'         | ...
+#'         `-- util
+#' ```
+#'
+#'   `/opt/NONMEM/` contains two NONMEM installations, one for NONMEM 7.5
+#'   and one for NONMEM 7.4.  In this case, you should pass `"/opt/NONMEM"`
+#'   as `.nonmem_dir` and either `"nm74"` or `"nm75"` as `.nonmem_version`.
+#'
 #'
 #' @param .dir Path to directory to run `init` in (and put the resulting
 #'   `bbi.yaml` file)
@@ -355,10 +374,10 @@ bbi_help <- function(.cmd_args=NULL) {
 #' @examples
 #' \dontrun{
 #'
-#' # NONMEM executable found at `/opt/NONMEM/nm75/run`:
+#' # Top-level of NONMEM 7.5 installation is at `/opt/NONMEM/nm75`:
 #'
 #' bbi_init(
-#'    .dir = "inst/model/nonmem/basic",
+#'    .dir = MODEL_DIR,
 #'    .nonmem_dir = "/opt/NONMEM",
 #'    .nonmem_version = "nm75"
 #' )

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -321,9 +321,22 @@ bbi_help <- function(.cmd_args=NULL) {
 #'   model. `submit_model()` and `submit_models()` also support passing a
 #'   configuration file via the `.config_path` argument.
 #'
+#'  **Notes on `.nonmem_dir`**
+#'
+#'   `bbi` tries to detect subdirectories for different NONMEM versions, along
+#'   with a license file and executable within the subdirectory. `.nonmem_dir`
+#'   should therefore point to the *parent* directory containing the executable.
+#'
+#'   If your NONMEM executable exists in the the location `/opt/NONMEM/nm75/run`,
+#'   `.nonmem_dir` should point to `/opt/NONMEM/`, rather than the subdirectory
+#'   `/opt/NONMEM/nm75`. You would then denote the preferred NONMEM version by
+#'   specifying `.nonmem_version = 'nm75'`
+#'
 #' @param .dir Path to directory to run `init` in (and put the resulting
 #'   `bbi.yaml` file)
-#' @param .nonmem_dir Path to directory with the NONMEM installation.
+#' @param .nonmem_dir Path to directory with the NONMEM installation. This
+#'   should be the **parent** directory that contains that installation. See
+#'   details for more information.
 #' @param .nonmem_version Character scalar for default version of NONMEM to use.
 #'   If left NULL, function will exit and tell you which versions were found in
 #'   `.nonmem_dir`
@@ -338,6 +351,18 @@ bbi_help <- function(.cmd_args=NULL) {
 #'
 #' @importFrom yaml read_yaml write_yaml
 #' @importFrom fs dir_exists
+#'
+#' @examples
+#' \dontrun{
+#'
+#' # NONMEM executable found at `/opt/NONMEM/nm75/run`:
+#'
+#' bbi_init(
+#'    .dir = "inst/model/nonmem/basic",
+#'    .nonmem_dir = "/opt/NONMEM",
+#'    .nonmem_version = "nm75"
+#' )
+#' }
 #' @export
 bbi_init <- function(.dir, .nonmem_dir, .nonmem_version = NULL, .bbi_args = NULL, .no_default_version = FALSE) {
   # check that destination directory exists

--- a/R/bbr.R
+++ b/R/bbr.R
@@ -323,9 +323,6 @@ bbi_help <- function(.cmd_args=NULL) {
 #'
 #'  **Notes on `.nonmem_dir`**
 #'
-#'   `bbi` tries to detect subdirectories for different NONMEM versions, along
-#'   with a license file and executable within the subdirectory.
-#'
 #'   `.nonmem_dir` should point to the **parent** directory that contains one
 #'   or more NONMEM installations.  It should *not* point to the installation
 #'   directory itself.  Here is an example:
@@ -353,9 +350,8 @@ bbi_help <- function(.cmd_args=NULL) {
 #'
 #' @param .dir Path to directory to run `init` in (and put the resulting
 #'   `bbi.yaml` file)
-#' @param .nonmem_dir Path to directory with the NONMEM installation. This
-#'   should be the **parent** directory that contains that installation. See
-#'   details for more information.
+#' @param .nonmem_dir Path to **parent** directory containing one or more NONMEM
+#'  installations. See details for more information.
 #' @param .nonmem_version Character scalar for default version of NONMEM to use.
 #'   If left NULL, function will exit and tell you which versions were found in
 #'   `.nonmem_dir`

--- a/man/bbi_init.Rd
+++ b/man/bbi_init.Rd
@@ -16,7 +16,9 @@ bbi_init(
 \item{.dir}{Path to directory to run \code{init} in (and put the resulting
 \code{bbi.yaml} file)}
 
-\item{.nonmem_dir}{Path to directory with the NONMEM installation.}
+\item{.nonmem_dir}{Path to directory with the NONMEM installation. This
+should be the \strong{parent} directory that contains that installation. See
+details for more information.}
 
 \item{.nonmem_version}{Character scalar for default version of NONMEM to use.
 If left NULL, function will exit and tell you which versions were found in
@@ -42,4 +44,27 @@ For \code{bbr} to make any calls out to \code{bbi} (for example in
 The default behavior is to look for this file in the same directory as the
 model. \code{submit_model()} and \code{submit_models()} also support passing a
 configuration file via the \code{.config_path} argument.
+
+\strong{Notes on \code{.nonmem_dir}}
+
+\code{bbi} tries to detect subdirectories for different NONMEM versions, along
+with a license file and executable within the subdirectory. \code{.nonmem_dir}
+should therefore point to the \emph{parent} directory containing the executable.
+
+If your NONMEM executable exists in the the location \verb{/opt/NONMEM/nm75/run},
+\code{.nonmem_dir} should point to \verb{/opt/NONMEM/}, rather than the subdirectory
+\verb{/opt/NONMEM/nm75}. You would then denote the preferred NONMEM version by
+specifying \code{.nonmem_version = 'nm75'}
+}
+\examples{
+\dontrun{
+
+# NONMEM executable found at `/opt/NONMEM/nm75/run`:
+
+bbi_init(
+   .dir = "inst/model/nonmem/basic",
+   .nonmem_dir = "/opt/NONMEM",
+   .nonmem_version = "nm75"
+)
+}
 }

--- a/man/bbi_init.Rd
+++ b/man/bbi_init.Rd
@@ -16,9 +16,8 @@ bbi_init(
 \item{.dir}{Path to directory to run \code{init} in (and put the resulting
 \code{bbi.yaml} file)}
 
-\item{.nonmem_dir}{Path to directory with the NONMEM installation. This
-should be the \strong{parent} directory that contains that installation. See
-details for more information.}
+\item{.nonmem_dir}{Path to \strong{parent} directory containing one or more NONMEM
+installations. See details for more information.}
 
 \item{.nonmem_version}{Character scalar for default version of NONMEM to use.
 If left NULL, function will exit and tell you which versions were found in
@@ -46,9 +45,6 @@ model. \code{submit_model()} and \code{submit_models()} also support passing a
 configuration file via the \code{.config_path} argument.
 
 \strong{Notes on \code{.nonmem_dir}}
-
-\code{bbi} tries to detect subdirectories for different NONMEM versions, along
-with a license file and executable within the subdirectory.
 
 \code{.nonmem_dir} should point to the \strong{parent} directory that contains one
 or more NONMEM installations.  It should \emph{not} point to the installation

--- a/man/bbi_init.Rd
+++ b/man/bbi_init.Rd
@@ -48,21 +48,38 @@ configuration file via the \code{.config_path} argument.
 \strong{Notes on \code{.nonmem_dir}}
 
 \code{bbi} tries to detect subdirectories for different NONMEM versions, along
-with a license file and executable within the subdirectory. \code{.nonmem_dir}
-should therefore point to the \emph{parent} directory containing the executable.
+with a license file and executable within the subdirectory.
 
-If your NONMEM executable exists in the the location \verb{/opt/NONMEM/nm75/run},
-\code{.nonmem_dir} should point to \verb{/opt/NONMEM/}, rather than the subdirectory
-\verb{/opt/NONMEM/nm75}. You would then denote the preferred NONMEM version by
-specifying \code{.nonmem_version = 'nm75'}
+\code{.nonmem_dir} should point to the \strong{parent} directory that contains one
+or more NONMEM installations.  It should \emph{not} point to the installation
+directory itself.  Here is an example:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{    /opt/NONMEM/
+    |-- nm74
+    |   |-- license
+    |   |-- run
+    |   |-- source
+    |   | ...
+    |   `-- util
+    `-- nm75
+        |-- license
+        |-- run
+        |-- source
+        | ...
+        `-- util
+}\if{html}{\out{</div>}}
+
+\verb{/opt/NONMEM/} contains two NONMEM installations, one for NONMEM 7.5
+and one for NONMEM 7.4.  In this case, you should pass \code{"/opt/NONMEM"}
+as \code{.nonmem_dir} and either \code{"nm74"} or \code{"nm75"} as \code{.nonmem_version}.
 }
 \examples{
 \dontrun{
 
-# NONMEM executable found at `/opt/NONMEM/nm75/run`:
+# Top-level of NONMEM 7.5 installation is at `/opt/NONMEM/nm75`:
 
 bbi_init(
-   .dir = "inst/model/nonmem/basic",
+   .dir = MODEL_DIR,
    .nonmem_dir = "/opt/NONMEM",
    .nonmem_version = "nm75"
 )


### PR DESCRIPTION
 - It became apparent that we needed more clear documentation surrounding the NONMEM installation directory (`.nonmem_dir` argument), as users were incorrectly passing the directory containing the executable file, rather than the parent directory.

 - Added more context to the parameter itself, along with some additional details and an example.


closes https://github.com/metrumresearchgroup/bbr/issues/607