### PR TITLE
add .bbi_args argument to inherit_param_estimates

### DIFF
--- a/R/inherit-param-estimates.R
+++ b/R/inherit-param-estimates.R
@@ -14,6 +14,10 @@
 #' @param bounds Whether to keep or discard the existing bounds when setting
 #'   the initial estimates in THETA records.
 #' @param digits Number of significant digits to round estimates to.
+#' @param .bbi_args Named list passed to `model_summary(.bbi_args)`. See
+#'   [print_bbi_args()] for valid options. Defaults to `list(no_grd_file = TRUE,
+#'   no_shk_file = TRUE)` because [model_summary()] is only called internally to
+#'   extract the parameter estimates, so those files are irrelevant.
 #'
 #'
 #' @details
@@ -46,7 +50,9 @@ inherit_param_estimates <- function(
     .parent_mod = get_based_on(.mod)[1],
     inherit = c("theta", "sigma", "omega"),
     bounds = c("keep", "discard"),
-    digits = 3
+    digits = 3,
+    .bbi_args = list(no_grd_file = TRUE,
+                     no_shk_file = TRUE)
 ){
 
   test_nmrec_version(.min_version = "0.3.0")
@@ -67,7 +73,7 @@ inherit_param_estimates <- function(
   mod_lines <- nmrec::read_ctl(mod_path)
 
   # Parent model objects
-  based_on_sum <- model_summary(.parent_mod)
+  based_on_sum <- model_summary(.parent_mod, .bbi_args = .bbi_args)
 
 
   fmt_digits <- paste0("%.",digits,"G")

--- a/man/inherit_param_estimates.Rd
+++ b/man/inherit_param_estimates.Rd
@@ -9,7 +9,8 @@ inherit_param_estimates(
   .parent_mod = get_based_on(.mod)[1],
   inherit = c("theta", "sigma", "omega"),
   bounds = c("keep", "discard"),
-  digits = 3
+  digits = 3,
+  .bbi_args = list(no_grd_file = TRUE, no_shk_file = TRUE)
 )
 }
 \arguments{
@@ -26,6 +27,10 @@ replacing all of THETA, SIGMA, and OMEGA}
 the initial estimates in THETA records.}
 
 \item{digits}{Number of significant digits to round estimates to.}
+
+\item{.bbi_args}{Named list passed to \code{model_summary(.bbi_args)}. See
+\code{\link[=print_bbi_args]{print_bbi_args()}} for valid options. Defaults to \code{list(no_grd_file = TRUE, no_shk_file = TRUE)} because \code{\link[=model_summary]{model_summary()}} is only called internally to
+extract the parameter estimates, so those files are irrelevant.}
 }
 \description{
 Set the initial parameter estimates of a model using the estimates of a

--- a/tests/testthat/test-inherit-param-estimates.R
+++ b/tests/testthat/test-inherit-param-estimates.R
@@ -205,9 +205,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
         # works correctly with flag added
         args_list <- list()
         args_list[[as.character(glue::glue("no_{.tc$ext}_file"))]] <- TRUE
-        expect_no_error(
-          mod3 <- inherit_param_estimates(mod3, .bbi_args = args_list)
-        )
+        mod3 <- inherit_param_estimates(mod3, .bbi_args = args_list)
 
         delete_models(list(mod2, mod3), .tags = NULL, .force = TRUE)
       }


### PR DESCRIPTION
Add `.bbi_args` argument to inherit_param_estimates, defaulting to `list(no_grd_file = TRUE, no_shk_file = TRUE)`, as we only need to extract parameter estimates.

closes https://github.com/metrumresearchgroup/bbr/issues/637