### PR TITLE
`inherit_param_estimates` tests fail outside of Drone or Metworx 

### DIFF
--- a/tests/testthat/test-inherit-param-estimates.R
+++ b/tests/testthat/test-inherit-param-estimates.R
@@ -39,6 +39,7 @@ get_param_inits <- function(.mod, init_only = TRUE){
 withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   describe("inherit_param_estimates: integration", {
     skip_if_old_nmrec("0.3.0")
+    skip_if_not_drone_or_metworx("inherit_param_estimates() summary object")
     it("base model", {
       # errors if no based_on field
       expect_error(inherit_param_estimates(MOD1), "did not return any parent models")


### PR DESCRIPTION
skip tests requiring `SUM1` if not on drone or metworx

closes https://github.com/metrumresearchgroup/bbr/issues/639