### PR TITLE
param_estimates_batch: don't rely on fread's header guess

### DIFF
--- a/R/param-estimates-batch.R
+++ b/R/param-estimates-batch.R
@@ -78,7 +78,7 @@ param_estimates_batch <- function(.path,
     }
   )
 
-  df <- as_tibble(fread(text = res$stdout))
+  df <- as_tibble(fread(text = res$stdout, header = TRUE))
 
   # throw out extra column that gets created if no models succeeded
   if ("V4" %in% names(df)) df <- select(df, -"V4")


### PR DESCRIPTION
param_estimates_batch() consumes `bbi nonmem params --dir ...` output. That has a header such as

    dir,error,termination,THETA1,[...],SIGMA(1_1),[...],OMEGA(2_2)

When feeding those lines to fread(), we do not specify that there is a header and instead let fread() guess.

The recent data.table 1.15.0 release includes a change to the guessing strategy: f83123f3 (fread improve containing header guess, 2021-11-30).  With that commit, two param_estimates_batch() test cases fail because fread() incorrectly guesses that there isn't a header. The input for those cases look like this:

    [1] "dir,error,termination,"
    [2] "dirname,msg,,"

Tell fread() that the input has a header to avoid the problem.

Closes #647.