### PR TITLE
check_run_times docs: fix .return_times typo in example

### DIFF
--- a/R/test-threads.R
+++ b/R/test-threads.R
@@ -108,7 +108,7 @@ test_threads <- function(
 #'
 #' # If models have already finished:
 #' check_run_times(mods, .wait = FALSE)
-#' check_run_times(mods, .wait = FALSE, .return_times = "All")
+#' check_run_times(mods, .wait = FALSE, .return_times = "all")
 #' }
 #' @return A tibble with columns `threads` (number of threads) and `time`
 #'   (elapsed estimation time in seconds for test models).

--- a/man/check_run_times.Rd
+++ b/man/check_run_times.Rd
@@ -37,6 +37,6 @@ check_run_times(mods, .wait = TRUE, .return_times = c("estimation_time", "covari
 
 # If models have already finished:
 check_run_times(mods, .wait = FALSE)
-check_run_times(mods, .wait = FALSE, .return_times = "All")
+check_run_times(mods, .wait = FALSE, .return_times = "all")
 }
 }


### PR DESCRIPTION
A check_run_times() example passes "All" for `.return_times`, but the function expects "all".