### PR TITLE
check_file: add final newline to printed output

### DIFF
--- a/R/read-output.R
+++ b/R/read-output.R
@@ -47,7 +47,7 @@ check_file <- function(.file, .head = 3, .tail = 5, .print = TRUE, .return = FAL
 
   # return and/or print
   if (.print) {
-    cat(paste(res_vec, collapse="\n"))
+    cat(paste(res_vec, collapse="\n"), "\n")
   }
   if (.return) {
     return(res_vec)


### PR DESCRIPTION
check_file() prints its output without a final newline.  That renders okay in the RStudio console, which takes care of adding a missing newline, but it can lead to a misplaced prompt in other consoles. Example from a plain R terminal console:

    > tail_lst("inst/model/nonmem/basic/1", .head = 0, .tail = 2)
    ...
    Stop Time:
    Mon Nov  8 11:35:08 EST 2021> CURSOR HERE