### PR TITLE
tail_*: don't hard code target when passed 'model path'

### DIFF
--- a/R/read-output.R
+++ b/R/read-output.R
@@ -12,6 +12,7 @@
 #' @importFrom readr read_lines
 #' @export
 check_file <- function(.file, .head = 3, .tail = 5, .print = TRUE, .return = FALSE) {
+  checkmate::assert_string(.file)
   l <- read_lines(.file)
 
   l_len <- length(l)

--- a/R/read-output.R
+++ b/R/read-output.R
@@ -70,6 +70,7 @@ tail_output <- function(.mod, ...) {
 #' @describeIn check_file Tail the OUTPUT file from a file path to a model.
 #' @export
 tail_output.character <- function(.mod, .head = 3, .tail = 5, .print = TRUE, .return = FALSE, ...) {
+  checkmate::assert_string(.mod)
   # if model path passed, construct path
   if (basename(.mod) != "OUTPUT") {
     .mod = as.character(file.path(.mod, "OUTPUT"))
@@ -117,6 +118,7 @@ tail_lst <- function(.mod, ...) {
 #' @describeIn check_file Tail the .lst file from a file path to a model.
 #' @export
 tail_lst.character <- function(.mod, .head = 3, .tail = 5, .print = TRUE, .return = FALSE, ...) {
+  checkmate::assert_string(.mod)
   # if model path passed, construct path
   if (tools::file_ext(.mod) != "lst") {
     .mod = as.character(file.path(.mod, paste0(get_model_id(.mod), ".lst")))
@@ -245,6 +247,7 @@ check_grd <- function(.mod, .iter_floor = 0) {
 #' @describeIn check_nonmem_table_output Checks .grd file from a file path
 #' @export
 check_grd.character <- function(.mod, .iter_floor = 0) {
+  checkmate::assert_string(.mod)
   # if model path passed, construct path
   if (tools::file_ext(.mod) != "grd") {
     .mod = as.character(file.path(.mod, paste0(get_model_id(.mod), ".grd")))
@@ -286,6 +289,7 @@ check_ext <- function(.mod, .iter_floor = 0) {
 #' @describeIn check_nonmem_table_output Checks .ext file from a file path
 #' @export
 check_ext.character <- function(.mod, .iter_floor = 0) {
+  checkmate::assert_string(.mod)
   # if model path passed, construct path
   if (tools::file_ext(.mod) != "ext") {
     .mod = as.character(file.path(.mod, paste0(get_model_id(.mod), ".ext")))

--- a/R/read-output.R
+++ b/R/read-output.R
@@ -71,9 +71,15 @@ tail_output <- function(.mod, ...) {
 #' @export
 tail_output.character <- function(.mod, .head = 3, .tail = 5, .print = TRUE, .return = FALSE, ...) {
   checkmate::assert_string(.mod)
-  # if model path passed, construct path
+  # If model path passed, rely on model method to construct path.
   if (basename(.mod) != "OUTPUT") {
-    .mod = as.character(file.path(.mod, "OUTPUT"))
+    return(
+      tail_output(
+        read_model(.mod),
+        .head = .head, .tail = .tail, .print = .print, .return = .return,
+        ...
+      )
+    )
   }
 
   check_file(.mod, .head, .tail, .print, .return, ...)
@@ -119,9 +125,15 @@ tail_lst <- function(.mod, ...) {
 #' @export
 tail_lst.character <- function(.mod, .head = 3, .tail = 5, .print = TRUE, .return = FALSE, ...) {
   checkmate::assert_string(.mod)
-  # if model path passed, construct path
+  # If model path passed, rely on model method to construct path.
   if (tools::file_ext(.mod) != "lst") {
-    .mod = as.character(file.path(.mod, paste0(get_model_id(.mod), ".lst")))
+    return(
+      tail_lst(
+        read_model(.mod),
+        .head = .head, .tail = .tail, .print = .print, .return = .return,
+        ...
+      )
+    )
   }
 
   check_file(.mod, .head, .tail, .print, .return, ...)


### PR DESCRIPTION
`tail_output.character` and `tail_lst.character` aren't compatible with nmbayes models.  The second commit fixes that.  

The first commit adds an argument check for various `*.character` methods in this file.  It's not conceptually related to the second commit, but I'm including it as cleanup here to avoid a merge conflict.