### PR TITLE
nm_join: abort and point to nm_join_bayes if passed nmbayes model

### DIFF
--- a/R/nm-join.R
+++ b/R/nm-join.R
@@ -92,6 +92,12 @@ nm_join <- function(
     no_shk_file = TRUE
   )
 ) {
+  if (inherits(.mod, "bbi_nmbayes_model")) {
+    stop(
+      "nm_join() is not supported for nmbayes models; ",
+      "use `bbr.bayes::nm_join_bayes()` instead."
+    )
+  }
 
   if (inherits(.mod, "character")) {
     checkmate::assert_string(.mod)


### PR DESCRIPTION
nm_join() is incompatible with nmbayes models (it will fail looking for the files in the top-level output directory).

bbr in general avoids embedding information about bbr.bayes, but there are already some exceptions.  Make one here too to point callers in the right direction.

Re: https://github.com/metrumresearchgroup/bbr.bayes/issues/36

