### PR TITLE
README: rework overview and point to bbr.bayes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -20,9 +20,9 @@ knitr::opts_chunk$set(
 [![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
-`bbr` is an R interface for running `bbi`. Together they provide a solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
-
 `bbr` is intended to help scientists manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools--like simple tagging of models and model inheritance trees--make reproducibility and external review much more streamlined.
+
+`bbr` is an R interface for running `bbi`. Together they provide a solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 `bbr` helps manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools---such as simple tagging of models and model inheritance trees---make reproducibility and external review more streamlined.
 
-`bbr` is an R interface for running `bbi`. Together they provide a solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
+`bbr` is an R interface for running `bbi`. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 [![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
-`bbr` helps manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools---such as simple tagging of models and model inheritance trees---make reproducibility and external review more streamlined.
+`bbr` helps manage the entire modeling workflow from within R. Users can submit models, inspect output and diagnostics, and iterate on models. Furthermore, workflow tools---such as simple tagging of models and model inheritance trees---make reproducibility and external review more streamlined.
 
 `bbr` supports running NONMEM models via the [bbi](https://github.com/metrumresearchgroup/bbi) command-line tool, with a focus on non-Bayesian methods. The [bbr.bayes](https://github.com/metrumresearchgroup/bbr.bayes) package extends `bbr` to enable Bayesian estimation through either NONMEM or [Stan](https://mc-stan.org/).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 `bbr` is an R interface for running `bbi`. Together they provide a solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
 
-`bbr` is intended to help scientists manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools--like simple tagging of models and model inheritence trees--make reproducibility and external review much more streamlined.
+`bbr` is intended to help scientists manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools--like simple tagging of models and model inheritance trees--make reproducibility and external review much more streamlined.
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 `bbr` helps manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools---such as simple tagging of models and model inheritance trees---make reproducibility and external review more streamlined.
 
-`bbr` is an R interface for running `bbi`. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
+`bbr` supports running NONMEM models via the [bbi](https://github.com/metrumresearchgroup/bbi) command-line tool, with a focus on non-Bayesian methods. The [bbr.bayes](https://github.com/metrumresearchgroup/bbr.bayes) package extends `bbr` to enable Bayesian estimation through either NONMEM or [Stan](https://mc-stan.org/).
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 [![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
-`bbr` is intended to help scientists manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools--like simple tagging of models and model inheritance trees--make reproducibility and external review much more streamlined.
+`bbr` helps manage the entire modeling workflow from within R. Users can submit models, consume outputs and diagnostics, and iterate on models. Furthermore, workflow tools---such as simple tagging of models and model inheritance trees---make reproducibility and external review more streamlined.
 
 `bbr` is an R interface for running `bbi`. Together they provide a solution for managing projects involving modeling and simulation with a number of software solutions used in pharmaceutical sciences. Currently, only NONMEM modeling is supported, though we are in the process of Stan with plans for other modeling software as well. You can get more detailed information on `bbi` (the underlying CLI tool)  [here](https://github.com/metrumresearchgroup/bbi).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/bbr/sta
 <!-- badges: end -->
 
 `bbr` helps manage the entire modeling workflow from within R. Users can
-submit models, consume outputs and diagnostics, and iterate on models.
+submit models, inspect output and diagnostics, and iterate on models.
 Furthermore, workflow tools—such as simple tagging of models and model
 inheritance trees—make reproducibility and external review more
 streamlined.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Furthermore, workflow tools—such as simple tagging of models and model
 inheritance trees—make reproducibility and external review more
 streamlined.
 
-`bbr` is an R interface for running `bbi`. Currently, only NONMEM
-modeling is supported, though we are in the process of Stan with plans
-for other modeling software as well. You can get more detailed
-information on `bbi` (the underlying CLI tool)
-[here](https://github.com/metrumresearchgroup/bbi).
+`bbr` supports running NONMEM models via the
+[bbi](https://github.com/metrumresearchgroup/bbi) command-line tool,
+with a focus on non-Bayesian methods. The
+[bbr.bayes](https://github.com/metrumresearchgroup/bbr.bayes) package
+extends `bbr` to enable Bayesian estimation through either NONMEM or
+[Stan](https://mc-stan.org/).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ detailed information on `bbi` (the underlying CLI tool)
 `bbr` is intended to help scientists manage the entire modeling workflow
 from within R. Users can submit models, consume outputs and diagnostics,
 and iterate on models. Furthermore, workflow tools–like simple tagging
-of models and model inheritence trees–make reproducibility and external
+of models and model inheritance trees–make reproducibility and external
 review much more streamlined.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/bbr/sta
 [![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
+`bbr` is intended to help scientists manage the entire modeling workflow
+from within R. Users can submit models, consume outputs and diagnostics,
+and iterate on models. Furthermore, workflow tools–like simple tagging
+of models and model inheritance trees–make reproducibility and external
+review much more streamlined.
+
 `bbr` is an R interface for running `bbi`. Together they provide a
 solution for managing projects involving modeling and simulation with a
 number of software solutions used in pharmaceutical sciences. Currently,
@@ -17,12 +23,6 @@ only NONMEM modeling is supported, though we are in the process of Stan
 with plans for other modeling software as well. You can get more
 detailed information on `bbi` (the underlying CLI tool)
 [here](https://github.com/metrumresearchgroup/bbi).
-
-`bbr` is intended to help scientists manage the entire modeling workflow
-from within R. Users can submit models, consume outputs and diagnostics,
-and iterate on models. Furthermore, workflow tools–like simple tagging
-of models and model inheritance trees–make reproducibility and external
-review much more streamlined.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ Furthermore, workflow tools—such as simple tagging of models and model
 inheritance trees—make reproducibility and external review more
 streamlined.
 
-`bbr` is an R interface for running `bbi`. Together they provide a
-solution for managing projects involving modeling and simulation with a
-number of software solutions used in pharmaceutical sciences. Currently,
-only NONMEM modeling is supported, though we are in the process of Stan
-with plans for other modeling software as well. You can get more
-detailed information on `bbi` (the underlying CLI tool)
+`bbr` is an R interface for running `bbi`. Currently, only NONMEM
+modeling is supported, though we are in the process of Stan with plans
+for other modeling software as well. You can get more detailed
+information on `bbi` (the underlying CLI tool)
 [here](https://github.com/metrumresearchgroup/bbi).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/bbr/sta
 [![codecov](https://codecov.io/gh/metrumresearchgroup/bbr/branch/main/graph/badge.svg)](https://codecov.io/gh/metrumresearchgroup/bbr)
 <!-- badges: end -->
 
-`bbr` is intended to help scientists manage the entire modeling workflow
-from within R. Users can submit models, consume outputs and diagnostics,
-and iterate on models. Furthermore, workflow tools–like simple tagging
-of models and model inheritance trees–make reproducibility and external
-review much more streamlined.
+`bbr` helps manage the entire modeling workflow from within R. Users can
+submit models, consume outputs and diagnostics, and iterate on models.
+Furthermore, workflow tools—such as simple tagging of models and model
+inheritance trees—make reproducibility and external review more
+streamlined.
 
 `bbr` is an R interface for running `bbi`. Together they provide a
 solution for managing projects involving modeling and simulation with a


### PR DESCRIPTION
As noted by @timwaterhouse in gh-668, the README has a stale mention work-in-progress Stan support without reference to bbr.bayes.

I didn't find a way to add that reference in a way that I thought flowed well with the current structure, so this does a larger rework of the overview section.  @timwaterhouse @seth127 I'd appreciate any thoughts or suggestions on that wider change.

---

- [ ] regenerate site after this lands
