### PR TITLE
Remove parenthesis from THETA names in initial_estimates()

### DIFF
--- a/R/initial-estimates.R
+++ b/R/initial-estimates.R
@@ -29,7 +29,7 @@ initial_estimates <- function(.mod, flag_fixed = FALSE){
 
   # THETA labels
   theta_inits <- initial_est$thetas
-  theta_inits$parameter_names <- sprintf("THETA(%d)", 1:nrow(theta_inits))
+  theta_inits$parameter_names <- sprintf("THETA%d", 1:nrow(theta_inits))
   theta_inits <- theta_inits %>%
     dplyr::rename("lower_bound" = "low", "upper_bound" = "up")
 


### PR DESCRIPTION
Remove parenthesis from THETA names in `initial_estimates()`

The intent here was to make the presentation of THETA names match the output from `param_estimates()` so initial and final estimates could be more easily joined together:
```r
> MOD1 %>% model_summary() %>% param_estimates() %>% left_join(initial_estimates(MOD1))
Joining with `by = join_by(parameter_names)`                                                                                                                                          
# A tibble: 9 × 13
  parameter_names estimate   stderr random_effect_sd random_effect_sdse fixed diag  shrinkage  init lower_bound upper_bound record_type
  <chr>              <dbl>    <dbl>            <dbl>              <dbl> <lgl> <lgl>     <dbl> <dbl>       <dbl>       <dbl> <chr>      
1 THETA1            2.32   8.72e- 2           NA              NA        FALSE NA        NA     2              0          NA theta      
2 THETA2           54.6    3.38e+ 0           NA              NA        FALSE NA        NA     3              0          NA theta      
3 THETA3          463.     3.03e+ 1           NA              NA        FALSE NA        NA    10              0          NA theta      
4 THETA4           -0.0820 5.61e- 2           NA              NA        FALSE NA        NA     0.02          NA          NA theta      
5 THETA5            4.18   1.38e+ 0           NA              NA        FALSE NA        NA     1             NA          NA theta      
6 OMEGA(1,1)        0.0985 2.03e- 2            0.314           3.24e- 2 FALSE TRUE      17.5   0.05          NA          NA omega      
7 OMEGA(2,1)        0      1   e+10            0               1   e+10 TRUE  FALSE     NA    NA             NA          NA NA         
8 OMEGA(2,2)        0.157  2.72e- 2            0.396           3.44e- 2 FALSE TRUE       2.07  0.2           NA          NA omega      
9 SIGMA(1,1)        1      1   e+10            1               1   e+10 TRUE  TRUE       4.08  1             NA          NA sigma      
# ℹ 1 more variable: record_number <int>
```

More details are provided in the referenced issue.
closes https://github.com/metrumresearchgroup/bbr/issues/672