### PR TITLE
Check overwrite pre-submission

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -140,20 +140,23 @@ submit_model.bbi_nmboot_model <- function(
     ))
   }
 
-  outdir <- get_output_dir(.mod, .check_exists = FALSE)
-  if (fs::dir_exists(outdir)) {
-    if (isTRUE(.overwrite)) {
-      rlang::inform(glue("Overwriting existing bootstrap output directory {outdir}"))
-      fs::dir_delete(outdir)
-    } else {
-      stop(paste(
-        glue("Model output already exists at {outdir}."),
-        "Use submit_model(..., .overwrite = TRUE) to overwrite the existing output directory."
-      ))
+  boot_models <- get_boot_models(.mod)
+
+  if (!isTRUE(.dry_run)) {
+    outdirs <- purrr::map_chr(boot_models, ~ get_output_dir(.x, .check_exists = FALSE))
+    if (any(fs::dir_exists(outdirs))) {
+      if (isTRUE(.overwrite)) {
+        rlang::inform(glue("Overwriting existing bootstrap output directories in {get_output_dir(.mod)}"))
+        fs::dir_delete(outdirs)
+      } else {
+        stop(paste(
+          glue("Model output already exists in {get_output_dir(.mod)}."),
+          "Use submit_model(..., .overwrite = TRUE) to overwrite the existing output directories."
+        ))
+      }
     }
   }
 
-  boot_models <- get_boot_models(.mod)
   res <- if (!isTRUE(.dry_run) &&
              !is.null(.batch_size) &&
              .batch_size < length(boot_models)

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -259,12 +259,15 @@ submit_nonmem_model <- function(.mod,
   outdir <- get_output_dir(.mod, .check_exists = FALSE)
   if (fs::dir_exists(outdir)) {
     if (isTRUE(overwrite_requested)) {
+      rlang::inform(glue("Overwriting existing output directory in {outdir}"))
       fs::dir_delete(outdir)
     } else {
-      stop(paste(
-        glue("Model output already exists at {outdir}."),
-        "Either pass `.overwrite = TRUE` or use `.bbi_args` to overwrite the existing output directory."
-      ))
+      rlang::abort(
+        c(
+          glue("Model output already exists in {outdir}."),
+          "Either pass `.overwrite = TRUE` or use `.bbi_args` to overwrite the existing output directory."
+        )
+      )
     }
   }
 

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -117,14 +117,15 @@ submit_model.bbi_nmboot_model <- function(
     )
   }
 
-  # If bbi.yaml exists in the current modeling directory, and _not_ the nested
-  # bootstrap directory, copy it to there before running
-  model_dir <- get_model_working_directory(.mod)
-  boot_dir <- .mod[[ABS_MOD_PATH]]
-  bbi_yaml_path <- file.path(model_dir, "bbi.yaml")
-  if(fs::file_exists(bbi_yaml_path) && !fs::file_exists(file.path(boot_dir, "bbi.yaml"))){
-    fs::file_copy(bbi_yaml_path, file.path(boot_dir, "bbi.yaml"))
-    rlang::inform(glue("Inheriting `bbi.yaml` from `{model_dir}`"))
+  .config_path <- if (is.null(.config_path)) {
+    # Explicitly pass the default value because it's needed for the
+    # bootstrap runs, which happen one level deeper.
+    file.path(get_model_working_directory(.mod),
+              "bbi.yaml")
+  } else {
+    # Ensure that user-specified values work from the bootstrap
+    # subdirectory.
+    fs::path_abs(.config_path)
   }
 
   boot_models <- get_boot_models(.mod)

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -246,10 +246,17 @@ submit_nonmem_model <- function(.mod,
     isTRUE(yaml::read_yaml(cpath)[["overwrite"]])
   }
 
-  check_for_existing_output(
-    get_output_dir(.mod, .check_exists = FALSE),
-    overwrite_requested
-  )
+  outdir <- get_output_dir(.mod, .check_exists = FALSE)
+  if (fs::dir_exists(outdir)) {
+    if (isTRUE(overwrite_requested)) {
+      fs::dir_delete(outdir)
+    } else {
+      stop(paste(
+        glue("Model output already exists at {outdir}."),
+        "Either pass `.overwrite = TRUE` or use `.bbi_args` to overwrite the existing output directory."
+      ))
+    }
+  }
 
   if (.dry_run) {
     # construct fake res object
@@ -280,23 +287,3 @@ check_mode_argument <- function(.mode) {
   return(invisible(TRUE))
 }
 
-
-#' Private helper to look for existing model output and overwrite if necessary
-#' @param .path Path to output directory that will potentially be overwritten
-#' @param .overwrite Whether user has requested overwrite. This value can come
-#'   from a variety of sources, but these are consolidated by the calling code,
-#'   before being passed to this function.
-#' @importFrom fs dir_exists dir_delete
-#' @keywords internal
-check_for_existing_output <- function(.path, .overwrite) {
-  if (fs::dir_exists(.path)) {
-    if (isTRUE(.overwrite)) {
-      fs::dir_delete(.path)
-    } else {
-      stop(paste(
-        glue("Model output already exists at {.path}."),
-        "Either pass `.overwrite = TRUE` or use `.bbi_args` to overwrite the existing output directory."
-      ))
-    }
-  }
-}

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -170,7 +170,7 @@ submit_model.bbi_nmboot_model <- function(
       .mode = .mode,
       .overwrite = .overwrite,
       .config_path = .config_path,
-      stdout_path = file.path(boot_dir, "OUTPUT")
+      stdout_path = file.path(.mod[[ABS_MOD_PATH]], "OUTPUT")
     )
 
   } else {

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -149,10 +149,12 @@ submit_model.bbi_nmboot_model <- function(
         rlang::inform(glue("Overwriting existing bootstrap output directories in {get_output_dir(.mod)}"))
         fs::dir_delete(outdirs)
       } else {
-        stop(paste(
-          glue("Model output already exists in {get_output_dir(.mod)}."),
-          "Use submit_model(..., .overwrite = TRUE) to overwrite the existing output directories."
-        ))
+        rlang::abort(
+          c(
+            glue("Model output already exists in {get_output_dir(.mod)}."),
+            "Use submit_model(..., .overwrite = TRUE) to overwrite the existing output directories."
+          )
+        )
       }
     }
   }
@@ -160,7 +162,7 @@ submit_model.bbi_nmboot_model <- function(
   res <- if (!isTRUE(.dry_run) &&
              !is.null(.batch_size) &&
              .batch_size < length(boot_models)
-             ) {
+  ) {
     submit_batch_callr(
       .mods = boot_models,
       .batch_size = .batch_size,

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -236,6 +236,11 @@ submit_nonmem_model <- function(.mod,
     )
   }
 
+  if (.dry_run) {
+    # construct fake res object
+    return(bbi_dry_run(cmd_args, model_dir))
+  }
+
   # check overwrite and delete existing output, if requested
   overwrite_requested <- if (!is.null(.bbi_args[["overwrite"]])) {
     # if passed via .overwrite or .bbi_args, return this value
@@ -256,11 +261,6 @@ submit_nonmem_model <- function(.mod,
         "Either pass `.overwrite = TRUE` or use `.bbi_args` to overwrite the existing output directory."
       ))
     }
-  }
-
-  if (.dry_run) {
-    # construct fake res object
-    return(bbi_dry_run(cmd_args, model_dir))
   }
 
   # launch model

--- a/R/submit-models.R
+++ b/R/submit-models.R
@@ -132,6 +132,24 @@ submit_models.bbi_nonmem_models <- function(.mods,
     return(list(cmd_args = cmd_args, model_dir = model_dir))
   })
 
+  if (!isTRUE(.dry_run)) {
+    outdirs <- purrr::map_chr(.mods, ~ get_output_dir(.x, .check_exists = FALSE))
+    if (any(fs::dir_exists(outdirs))) {
+      outdirs_txt <- paste("\n-", paste(outdirs, collapse = "\n- "))
+      if (isTRUE(.overwrite)) {
+        rlang::inform(glue("Overwriting existing output directories in {outdirs_txt}"))
+        fs::dir_delete(outdirs)
+      } else {
+        rlang::abort(
+          c(
+            glue("Model output already exists in {outdirs_txt}."),
+            "Use submit_models(..., .overwrite = TRUE) to overwrite the existing output directories."
+          )
+        )
+      }
+    }
+  }
+
   message(glue("Submitting {length(.mods)} models with {length(cmd_args_list)} unique configurations."))
 
   if (.dry_run) {

--- a/R/submit-models.R
+++ b/R/submit-models.R
@@ -132,23 +132,6 @@ submit_models.bbi_nonmem_models <- function(.mods,
     return(list(cmd_args = cmd_args, model_dir = model_dir))
   })
 
-  if (!isTRUE(.dry_run)) {
-    outdirs <- purrr::map_chr(.mods, ~ get_output_dir(.x, .check_exists = FALSE))
-    if (any(fs::dir_exists(outdirs))) {
-      outdirs_txt <- paste("\n-", paste(outdirs, collapse = "\n- "))
-      if (isTRUE(.overwrite)) {
-        rlang::inform(glue("Overwriting existing output directories in {outdirs_txt}"))
-        fs::dir_delete(outdirs)
-      } else {
-        rlang::abort(
-          c(
-            glue("Model output already exists in {outdirs_txt}."),
-            "Use submit_models(..., .overwrite = TRUE) to overwrite the existing output directories."
-          )
-        )
-      }
-    }
-  }
 
   message(glue("Submitting {length(.mods)} models with {length(cmd_args_list)} unique configurations."))
 

--- a/man/submit_model.Rd
+++ b/man/submit_model.Rd
@@ -33,7 +33,7 @@ submit_model(
   .bbi_args = NULL,
   .mode = "sge",
   ...,
-  .overwrite = NULL,
+  .overwrite = FALSE,
   .config_path = NULL,
   .wait = FALSE,
   .dry_run = FALSE,
@@ -57,7 +57,11 @@ or set globally with \code{options("bbr.bbi_exe_mode")}.}
 \item{.overwrite}{Logical to specify whether or not to overwrite existing
 model output from a previous run. If \code{NULL}, the default, will defer to
 setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
-settings in \code{.bbi_args} or \code{bbi.yaml}.}
+settings in \code{.bbi_args} or \code{bbi.yaml}. \strong{The exception to this are
+bootstrap runs (\code{bbi_nmboot_model} objects).} For bootstrap runs, this
+defaults to \code{FALSE} and does \emph{not} respect any setting passed via
+\code{.bbi_args} or a \code{bbi.yaml} config file. To overwrite existing bootstrap
+output, a user must pass \code{TRUE} through this argument.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/man/submit_models.Rd
+++ b/man/submit_models.Rd
@@ -44,7 +44,11 @@ or set globally with \code{options("bbr.bbi_exe_mode")}.}
 \item{.overwrite}{Logical to specify whether or not to overwrite existing
 model output from a previous run. If \code{NULL}, the default, will defer to
 setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
-settings in \code{.bbi_args} or \code{bbi.yaml}.}
+settings in \code{.bbi_args} or \code{bbi.yaml}. \strong{The exception to this are
+bootstrap runs (\code{bbi_nmboot_model} objects).} For bootstrap runs, this
+defaults to \code{FALSE} and does \emph{not} respect any setting passed via
+\code{.bbi_args} or a \code{bbi.yaml} config file. To overwrite existing bootstrap
+output, a user must pass \code{TRUE} through this argument.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/tests/testthat/test-workflow-bbi.R
+++ b/tests/testthat/test-workflow-bbi.R
@@ -134,7 +134,7 @@ withr::with_options(list(
     )
     expect_error(
       proc <- submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE),
-      regexp = "Model output already exists"
+      regexp = "The target output directory already exists"
     )
 
     # check that .overwrite works
@@ -142,10 +142,7 @@ withr::with_options(list(
       submit_model(mod1, .mode = "local", .wait = TRUE, .overwrite = TRUE),
       "Overwriting existing output directory in"
     )
-    expect_message(
-      submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE, .overwrite = TRUE),
-      "Overwriting existing output directories in"
-    )
+    submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE, .overwrite = TRUE)
 
     log_df <- summary_log(MODEL_DIR_BBI)
 

--- a/tests/testthat/test-workflow-bbi.R
+++ b/tests/testthat/test-workflow-bbi.R
@@ -130,16 +130,23 @@ withr::with_options(list(
     # check that overwrite error parses correctly
     expect_error(
       submit_model(mod1, .mode = "local", .wait = TRUE),
-      regexp = "The target output directory already exists"
+      regexp = "Model output already exists"
     )
     expect_error(
-      submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE),
-      regexp = "The target output directory already exists"
+      proc <- submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE),
+      regexp = "Model output already exists"
     )
 
     # check that .overwrite works
-    submit_model(mod1, .mode = "local", .wait = TRUE, .overwrite = TRUE)
-    submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE, .overwrite = TRUE)
+    expect_message(
+      submit_model(mod1, .mode = "local", .wait = TRUE, .overwrite = TRUE),
+      "Overwriting existing output directory in"
+    )
+    expect_message(
+      submit_models(list(mod2, mod3), .mode = "local", .wait = TRUE, .overwrite = TRUE),
+      "Overwriting existing output directories in"
+    )
+
     log_df <- summary_log(MODEL_DIR_BBI)
 
     # check that models finished successfully
@@ -228,7 +235,7 @@ withr::with_options(list(
   test_that("wait_for_nonmem() correctly freezes the console [BBR-UTL-012]", {
     # create model
     mod1 <- read_model(file.path(MODEL_DIR_BBI, "1"))
-    submit_model(mod1, .mode = "local", .wait = FALSE)
+    submit_model(mod1, .mode = "local", .wait = FALSE, .overwrite = TRUE)
     wait_for_nonmem(mod1, 100, .interval = 5)
     expect_true(suppressMessages(nrow(nm_tab(mod1)) > 1))
   })

--- a/tests/testthat/test-workflow-bootstrap.R
+++ b/tests/testthat/test-workflow-bootstrap.R
@@ -218,6 +218,9 @@ withr::with_options(
       expect_error(
         cleanup_bootstrap_run(.boot_run), "Model has not been summarized yet"
       )
+
+      # Attempt to overwrite
+      expect_error(submit_model(.boot_run), "Model output already exists")
     })
 
     test_that("summarize_bootstrap_run works as expected", {

--- a/tests/testthat/test-workflow-bootstrap.R
+++ b/tests/testthat/test-workflow-bootstrap.R
@@ -299,10 +299,8 @@ withr::with_options(
 
       # Check model/data file existence
       files_kept <- fs::dir_ls(boot_dir, all = TRUE) %>% fs::path_rel(boot_dir)
-      expect_equal(
-        files_kept,
-        c(".gitignore", "bbi.yaml", "bbr_boot_spec.json", "boot_summary.RDS")
-      )
+      expect_equal(files_kept, c(".gitignore", "bbr_boot_spec.json", "boot_summary.RDS"))
+
 
       # Confirm boot spec alterations
       boot_spec <- get_boot_spec(.boot_run)


### PR DESCRIPTION
Addresses _part of_ #691 but not `submit_models()` (plural). We will discuss there, about whether to open that as a separate issue.

Also addresses strange overwrite behavior in unmerged bootstrap functionality (as of [1.10.0.8003](https://github.com/metrumresearchgroup/bbr/releases/tag/1.10.0.8003)). This was caused by passing the `overwrite` specification through the child models, which lead to unpredictable behavior, particularly in cases where a some of the child models had not finished running.

I attempted to give my detailed reasoning for these changes in the relevant commit messages. Here is a summary of the commits:

* 742e75f364a7a4b250126df744bc9d61bf016f65 addresses the issue in #691 and is unrelated to bootstrap models.
  * efcc5c7a1b776e8de6fbcccc8fa8cdcd292510d1 slightly refactors this, for clarity of code, but does not change the behavior.
* 4623c693106ef69ae6d40a9308f5210286938c0c is unrelated to all of this, but is a change that we had discussed making, and seemed like good clean up to do prior to the next commit.
* 9428c0fe56fff22c17cf639a4101a0a1a26ce8cc changes the behavior of overwriting bootstrap models. Notably, it ignore `.bbi_args` and the `bbi.yaml` and changes the default from `NULL` to `FALSE`. Again, my reasoning is detailed in the commit message. I am certainly open to discussion on this, but my current thinking is that this is the cleanest behavior and most likely to give the user what they expect.