### PR TITLE
Patch: Overwrite bootstrap RDS and OUTPUT

### DIFF
--- a/R/model-status.R
+++ b/R/model-status.R
@@ -264,9 +264,9 @@ get_model_status.default <- function(.mod, max_print = 10, ...){
   res_fin <- res$model_id[res$finished]
   if(length(res_fin) > 0 && length(res_fin) <= max_print){
     mods_fin <- paste(res_fin, collapse = ", ")
-    message(glue("\n The following model(s) have finished: `{mods_fin}`"))
+    message(glue("The following model(s) have finished: `{mods_fin}`"))
   }else{
-    message(glue("\n{length(res_fin)} model(s) have finished"))
+    message(glue("{length(res_fin)} model(s) have finished"))
   }
 
   res_inc <- res$model_id[!res$finished]
@@ -274,12 +274,12 @@ get_model_status.default <- function(.mod, max_print = 10, ...){
     mods_inc <- paste(res_inc, collapse = ", ")
     message(
       paste(
-        "\n The following model(s) are incomplete or have not yet been run:",
+        "The following model(s) are incomplete or have not been run:",
         glue("`{mods_inc}`")
       )
     )
   }else{
-    message(glue("\n{length(res_inc)} model(s) are incomplete"))
+    message(glue("{length(res_inc)} model(s) are incomplete or have not been run"))
   }
 
   return(invisible(res))

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -166,7 +166,7 @@ submit_model.bbi_nmboot_model <- function(
         )
       }
     } else {
-      if (isTRUE(.overwrite) && isTRUE(cleaned_up)) {
+      if (isTRUE(cleaned_up)) {
         # We dont want to delete anything if the model has been cleaned up
         #   - All output files would be deleted via:
         #     `setup_bootstrap_run(.boot_run, .overwrite = TRUE)`

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -148,6 +148,14 @@ submit_model.bbi_nmboot_model <- function(
       if (isTRUE(.overwrite)) {
         rlang::inform(glue("Overwriting existing bootstrap output directories in {get_output_dir(.mod)}"))
         fs::dir_delete(outdirs)
+
+        # delete other bootstrap artifacts from previous run
+        boot_output_path <- file.path(.mod[[ABS_MOD_PATH]], "OUTPUT")
+        if (fs::file_exists(boot_output_path)) fs::file_delete(boot_output_path)
+
+        boot_sum_path <- file.path(.mod[[ABS_MOD_PATH]], "boot_summary.RDS")
+        if (fs::file_exists(boot_sum_path)) fs::file_delete(boot_sum_path)
+
       } else {
         rlang::abort(
           c(

--- a/tests/testthat/test-model-status.R
+++ b/tests/testthat/test-model-status.R
@@ -30,7 +30,7 @@ describe("Model status helpers return the correct status", {
     expect_false(check_nonmem_finished(mod2))
     expect_message(
       get_model_status(mod2),
-      "The following model(s) are incomplete or have not yet been run: `2`",
+      "The following model(s) are incomplete or have not been run: `2`",
       fixed = TRUE
     )
 
@@ -50,7 +50,7 @@ describe("Model status helpers return the correct status", {
     expect_false(check_nonmem_finished(.boot_run))
     expect_message(
       get_model_status(.boot_run),
-      "The following model(s) are incomplete or have not yet been run: `1, 2`",
+      "The following model(s) are incomplete or have not been run: `1, 2`",
       fixed = TRUE
     )
     # Individual bootstrap models
@@ -70,7 +70,7 @@ describe("Model status helpers return the correct status", {
     expect_false(check_nonmem_finished(mod2))
     expect_message(
       get_model_status(mod2),
-      "The following model(s) are incomplete or have not yet been run: `2`",
+      "The following model(s) are incomplete or have not been run: `2`",
       fixed = TRUE
     )
   })
@@ -86,7 +86,7 @@ describe("Model status helpers return the correct status", {
     )
     expect_message(
       get_model_status(mod_list),
-      "The following model(s) are incomplete or have not yet been run: `2, 1-boot`",
+      "The following model(s) are incomplete or have not been run: `2, 1-boot`",
       fixed = TRUE
     )
   })

--- a/tests/testthat/test-workflow-bootstrap.R
+++ b/tests/testthat/test-workflow-bootstrap.R
@@ -325,5 +325,11 @@ withr::with_options(
       boot_spec <- get_boot_spec(.boot_run)
       expect_true(boot_spec$cleaned_up)
       expect_true(is.null(boot_spec$bootstrap_runs))
+
+      # Cannot be overwritten
+      expect_error(
+        submit_model(.boot_run, .overwrite = TRUE, .mode = "local"),
+        "Model has been cleaned up"
+      )
     })
   })


### PR DESCRIPTION
When overwriting existing bootstrap output directories, we should also be deleting the `OUTPUT` log file associated with them, as well as any `boot_summary.RDS` that we created _from_ them.

The `boot_summary.RDS` is especially important, because, if this is retained, it will be read in when the user calls summarize_bootstrap_run() on their re-run.