### PR TITLE
Patch/boot model path _not_ from RDS or JSON

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.10.0.8006
+Version: 1.10.0.8007
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/R/bootstrap-model.R
+++ b/R/bootstrap-model.R
@@ -478,6 +478,11 @@ summarize_bootstrap_run <- function(
     based_on_mod <- read_model(based_on_path)
     boot_sum$based_on_model_path <- get_model_path(based_on_mod)
     boot_sum$based_on_data_set <- get_data_path(based_on_mod)
+  } else {
+    # if not, set to "<not found>" to avoid confusion with stale paths
+    rlang::warn(glue("Bootstrap run {get_model_id(.boot_run)} cannot find parent model. Expected to be found at {based_on_path}"))
+    boot_sum$based_on_model_path <- "<not found>"
+    boot_sum$based_on_data_set <- "<not found>"
   }
 
   return(boot_sum)

--- a/R/bootstrap-model.R
+++ b/R/bootstrap-model.R
@@ -469,6 +469,11 @@ summarize_bootstrap_run <- function(
     boot_sum <- readRDS(boot_sum_path)
   }
 
+  # reset model path to current absolute path on this system (instead of what's pulled from RDS/JSON)
+  boot_sum[[ABS_MOD_PATH]] <- .boot_run[[ABS_MOD_PATH]]
+  # TODO: the based_on_model_path and based_on_data_set also need to be reset
+
+
   return(boot_sum)
 }
 

--- a/R/bootstrap-model.R
+++ b/R/bootstrap-model.R
@@ -471,8 +471,14 @@ summarize_bootstrap_run <- function(
 
   # reset model path to current absolute path on this system (instead of what's pulled from RDS/JSON)
   boot_sum[[ABS_MOD_PATH]] <- .boot_run[[ABS_MOD_PATH]]
-  # TODO: the based_on_model_path and based_on_data_set also need to be reset
 
+  # if parent model is present, reset based on paths as well
+  based_on_path <- get_based_on(.boot_run)[[1]]
+  if (fs::file_exists(paste0(based_on_path, ".yaml"))) {
+    based_on_mod <- read_model(based_on_path)
+    boot_sum$based_on_model_path <- get_model_path(based_on_mod)
+    boot_sum$based_on_data_set <- get_data_path(based_on_mod)
+  }
 
   return(boot_sum)
 }

--- a/R/print.R
+++ b/R/print.R
@@ -194,7 +194,7 @@ print.bbi_model <- function(x, ...) {
 #' @param .digits Number of significant digits to use for parameter table. Defaults to 3.
 #' @param .fixed If `FALSE`, the default, omits fixed parameters from the parameter table.
 #' @param .off_diag If `FALSE`, the default, omits off-diagonals of OMEGA and SIGMA matrices from the parameter table.
-#' @param .nrow If `NULL`, the default, print all rows of the parameter table.
+#' @param .nrow If `NULL`, the default, print all rows of the parameter table. If `0`, don't print table at all.
 #'   Otherwise, prints only `.nrow` rows.
 #' @export
 print.bbi_nonmem_summary <- function(x, .digits = 3, .fixed = FALSE, .off_diag = FALSE, .nrow = NULL, ...) {
@@ -277,8 +277,11 @@ print.bbi_nonmem_summary <- function(x, .digits = 3, .fixed = FALSE, .off_diag =
       capture.output()
   }
 
-  cat_line(param_str)
-  if (!is.null(.nrow)) cat_line(glue("... {orig_rows - .nrow} more rows"), col = "grey")
+  if (is.null(.nrow) || .nrow != 0) {
+    cat_line(param_str)
+    if (!is.null(.nrow)) cat_line(glue("... {orig_rows - .nrow} more rows"), col = "grey")
+  }
+
 }
 
 

--- a/man/print_bbi.Rd
+++ b/man/print_bbi.Rd
@@ -32,7 +32,7 @@ long option will be truncated.}
 
 \item{.off_diag}{If \code{FALSE}, the default, omits off-diagonals of OMEGA and SIGMA matrices from the parameter table.}
 
-\item{.nrow}{If \code{NULL}, the default, print all rows of the parameter table.
+\item{.nrow}{If \code{NULL}, the default, print all rows of the parameter table. If \code{0}, don't print table at all.
 Otherwise, prints only \code{.nrow} rows.}
 }
 \description{


### PR DESCRIPTION
This is necessary because the RDS and JSON have the absolute path on the system _where it was originally run_. This fails if someone is trying this on a different system. In other words, when you try to load a summary of something that someone else has run, then the paths that are loaded and displayed with be wrong (and part of the `print` method fails because of this).

<details>

Notice the RDS it's loading is on `sethg` system, but the "Based On" paths are from `kyleb`'s system (who actually ran the models).

And then, when it tries to read in the model in the print method, `.boot_run[[ABS_MOD_PATH]]` returns the `kyleb` path and fails.

```r
> bs <- summarize_bootstrap_run(br)
Reading in bootstrap summary: /data/home/sethg/projects/this-repo/models/pk/106-boot/boot_summary.RDS

> bs

── Based on ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Model: /data/home/kyleb/project.mrg/this-repo/models/pk/106.ctl
Dataset: /data/home/kyleb/project.mrg/this-repo/data/derived/pk.csv

── Run Specifications ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
• Stratification Columns: STUDY
• Seed: 1234
Error in read_model(.boot_run[[ABS_MOD_PATH]]) :
Assertion on 'yaml_path' failed: File does not exist: '/data/home/kyleb/project.mrg/this-repo/models/pk/106-boot.yaml'.
9.
stop(simpleError(sprintf(msg, ...), call.)) at helper.R#2
8.
mstop("Assertion on '%s' failed: %s.", var.name, res, call. = sys.call(-2L)) at makeAssertion.R#44
7.
makeAssertion(x, res, .var.name, add) at checkmate#1
6.
checkmate::assert_file_exists(yaml_path) at new-model.R#96
5.
read_model(.boot_run[[ABS_MOD_PATH]]) at model-status.R#119
4.
bootstrap_is_cleaned_up(x)
3.
isTRUE(bootstrap_is_cleaned_up(x)) at print.R#313
2.
print.bbi_nmboot_summary(x)
1.
(function (x, ...)
UseMethod("print"))(x)


```
</details>

------

Note that I also snuck bac2e4428750929ddeb70c8b85d2ac399df44070 into here, which is totally unrelated. It is a small change to facilitate a new style of diagnostics template and we keep forgetting to add it. Now it is in.