### PR TITLE
ci: update to latest bbi

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install bbi
         uses: metrumresearchgroup/actions/setup-bbi@v1
         with:
-          version: v3.3.0
+          version: v3.3.1
       - uses: metrumresearchgroup/actions/mpn-latest@v1
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  BBI_VERSION: v3.3.0
+  BBI_VERSION: v3.3.1
 
 jobs:
   check:


### PR DESCRIPTION
Routine bump to use recent bbi release.

(Eventually I'd like to update the [setup-bbi action](https://github.com/metrumresearchgroup/actions/tree/main/setup-bbi) to make it default to the latest version.) 