### PR TITLE
Add `size_by` argument to `model_tree()`

### DIFF
--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -173,7 +173,7 @@ model_tree.bbi_log_df <- function(
 
   # Format coloring
   tree_data <- color_tree_by(tree_data, color_by = color_by)
-  tree_attr <- ifelse(is.null(color_by), "leafCount", color_by)
+  tree_attr <- attributes(tree_data)$color_by
 
   # Format sizing
   tree_data <- size_tree_by(tree_data, size_by = size_by)
@@ -721,11 +721,15 @@ color_tree_by <- function(tree_data, color_by = "run"){
       tree_data$col <- factor(tree_data$col)
       levels(tree_data$col) <- c(node_colors, pal_bbr)
     }
+    # Set color_by attribute to color_by argument
+    attr(tree_data, "color_by") <- color_by
   }else{
     # all bbr red color
     pal_bbr <- scales::pal_gradient_n(bbr_cols)(1)
     tree_data$col <- factor(tree_data$col)
     levels(tree_data$col) <- c(node_colors, pal_bbr)
+    # Set color_by attribute to leafCount (default)
+    attr(tree_data, "color_by") <- "leafCount"
   }
 
   return(tree_data)
@@ -745,6 +749,7 @@ size_tree_by <- function(tree_data, size_by = NULL){
       # Set node sizes with NA values (including start node) to mean value
       mean_val <- mean(tree_data$node_size, na.rm = TRUE)
       tree_data$node_size[is.na(tree_data$node_size)] <- mean_val
+      # Set size_by attribute to node_size column
       attr(tree_data, "size_by") <- "node_size"
     }else{
       col_class <- class(tree_data[[size_by]])
@@ -757,6 +762,7 @@ size_tree_by <- function(tree_data, size_by = NULL){
       attr(tree_data, "size_by") <- "leafCount"
     }
   }else{
+    # Set size_by attribute to leafCount (default)
     attr(tree_data, "size_by") <- "leafCount"
   }
 

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -691,7 +691,7 @@ color_tree_by <- function(tree_data, color_by = "run"){
     n_levels <- dplyr::n_distinct(vals)
 
     # To preview color palette: scales::show_col(pal_bbr)
-    if(inherits(vals, "numeric")){
+    if(inherits(vals, c("numeric", "integer"))){
       # Gradient coloring (sorted): get colors for unique values (excluding NA)
       sorted_vals <- sort(unique(vals))
       pal_bbr <- scales::pal_gradient_n(bbr_cols)(seq(0, 1, length.out = n_levels))

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -648,6 +648,7 @@ make_tree_tooltip <- function(tree_data, digits = 3, font_size = 10){
       })
       paste0(other_html, collapse = "")
     })
+    other_tooltip[1] <- "" # Skip start node for other tooltips
     tooltip <- paste0(tooltip, other_tooltip, sum_tooltip)
   }else{
     tooltip <- paste0(tooltip, sum_tooltip)

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -680,7 +680,19 @@ color_tree_by <- function(tree_data, color_by = "run"){
     n_levels <- dplyr::n_distinct(vals)
 
     # To preview color palette: scales::show_col(pal_bbr)
-    if(inherits(vals, "logical")){
+    if(inherits(vals, "numeric")){
+      # Gradient coloring (sorted): get colors for unique values (excluding NA)
+      sorted_vals <- sort(unique(vals))
+      pal_bbr <- scales::pal_gradient_n(bbr_cols)(seq(0, 1, length.out = n_levels))
+
+      # Assign colors based on sorted values
+      color_mapping <- setNames(pal_bbr, sorted_vals)
+      tree_data$col <- ifelse(
+        tree_data$col %in% sorted_vals,
+        color_mapping[as.character(tree_data$col)],
+        tree_data$col
+      )
+    }else if(inherits(vals, "logical")){
       # Ensure both TRUE and FALSE colors are extracted, even if only one occurs
       pal_bbr <- scales::pal_gradient_n(bbr_cols)(c(0,1))
       # Explicitly set FALSE to white and TRUE to red
@@ -693,7 +705,7 @@ color_tree_by <- function(tree_data, color_by = "run"){
         )
       )
     }else{
-      # Gradient coloring: get colors for unique values (excluding NA)
+      # Gradient coloring; doesn't need to be sorted
       pal_bbr <- scales::pal_gradient_n(bbr_cols)(seq(0, 1, length.out = n_levels))
       tree_data$col <- factor(tree_data$col)
       levels(tree_data$col) <- c(node_colors, pal_bbr)

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -177,7 +177,7 @@ model_tree.bbi_log_df <- function(
 
   # Format sizing
   tree_data <- size_tree_by(tree_data, size_by = size_by)
-  node_size <- ifelse(is.null(size_by), "leafCount", "node_size")
+  node_size <- attributes(tree_data)$size_by
 
   # Compile attributes into tooltip
   tree_data <- make_tree_tooltip(tree_data, digits = digits, font_size = font_size)
@@ -745,18 +745,19 @@ size_tree_by <- function(tree_data, size_by = NULL){
       # Set node sizes with NA values (including start node) to mean value
       mean_val <- mean(tree_data$node_size, na.rm = TRUE)
       tree_data$node_size[is.na(tree_data$node_size)] <- mean_val
+      attr(tree_data, "size_by") <- "node_size"
     }else{
       col_class <- class(tree_data[[size_by]])
       cli::cli_warn(
         c(
           "Only numeric columns are supported. Column {.val {size_by}} is {.val {col_class}}",
-          "i" = "Setting node size to constant"
+          "i" = "Setting node size to Default"
         )
       )
-      tree_data$node_size <- 1
+      attr(tree_data, "size_by") <- "leafCount"
     }
   }else{
-    tree_data$node_size <- 1
+    attr(tree_data, "size_by") <- "leafCount"
   }
 
   return(tree_data)

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -8,8 +8,8 @@
 #'        identifying which models are starred, have heuristics, etc. See details
 #'        for more information.
 #' @param size_by A **numeric** (or integer) run log column to size the nodes by.
-#'        Can be helpful for sizing nodes by objective function values or
-#'        otherwise emphasizing notable differences in numeric columns.
+#'        If not specified, the default sizing is `'leafCount'`, which sizes the
+#'        nodes based on how many models are based on it.
 #' @param add_summary Logical (`TRUE`/`FALSE`). If `TRUE`, include key columns
 #'        from [model_summary()] output.
 #' @param digits Number of digits to round decimal places to for display in
@@ -169,7 +169,8 @@ model_tree.bbi_log_df <- function(
   stop_if_tree_missing_deps(static = static)
 
   # Make tree data
-  include_info <- unique(c(include_info, color_by, size_by))
+  # TODO: decide if we want to append color_by and size_by to tooltip automatically
+  # include_info <- unique(c(include_info, color_by, size_by))
   tree_data <- make_tree_data(.log_df, include_info, color_by, size_by, add_summary)
 
   # Format coloring

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -8,8 +8,8 @@
 #'        identifying which models are starred, have heuristics, etc. See details
 #'        for more information.
 #' @param size_by A **numeric** (or integer) run log column to size the nodes by.
-#'        If not specified, the default sizing is `'leafCount'`, which sizes the
-#'        nodes based on how many models are based on it.
+#'        If not specified, the default is to size the nodes based on how many
+#'        models are based on it.
 #' @param add_summary Logical (`TRUE`/`FALSE`). If `TRUE`, include key columns
 #'        from [model_summary()] output.
 #' @param digits Number of digits to round decimal places to for display in
@@ -54,7 +54,7 @@
 #'     - Note that the above summary columns will only receive the special
 #'     formatting if added via `add_summary = TRUE`.
 #'     - i.e. if `.log_df = run_log() %>% add_summary()` and
-#'     `include_info = 'ofv'`, The `'OFV'` parameter will display the same as if
+#'     `include_info = 'ofv'`, the `'OFV'` parameter will display the same as if
 #'     it was _not_ passed to `include_info`.
 #'
 #' **Coloring**
@@ -169,8 +169,6 @@ model_tree.bbi_log_df <- function(
   stop_if_tree_missing_deps(static = static)
 
   # Make tree data
-  # TODO: decide if we want to append color_by and size_by to tooltip automatically
-  # include_info <- unique(c(include_info, color_by, size_by))
   tree_data <- make_tree_data(.log_df, include_info, color_by, size_by, add_summary)
 
   # Format coloring

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -760,21 +760,10 @@ size_tree_by <- function(tree_data, size_by = NULL, rescale_to = c(1, 3)){
 
     # Scale size with numeric value
     if(inherits(tree_data$node_size, c("numeric", "integer"))){
-      # Rescale values based on standard deviation
-      # - a large SD can lead to very large nodes
-      mean_val <- mean(tree_data$node_size, na.rm = TRUE)
-      sd_val <- sd(tree_data$node_size, na.rm = TRUE)
-
-      if(sd_val != 0){
-        tree_data$node_size <- (tree_data$node_size - mean_val) / sd_val
-      }else{
-        # Would only happen if all values are the same
-        # - avoids dividing by 0
-        tree_data$node_size <- rep(1, length(tree_data$node_size))
-      }
 
       # Rescale to specified range
-      # Note: node sizes cannot be negative
+      # - node sizes must be greater than 0 (decimals are fine)
+      # - A large SD can lead to large nodes (max of rescale_to should be small)
       tree_data <- tree_data %>% dplyr::mutate(
         node_size = scales::rescale(.data$node_size, to = rescale_to)
       )

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -183,6 +183,14 @@ model_tree.bbi_log_df <- function(
   tree_data <- make_tree_tooltip(tree_data, digits = digits, font_size = font_size)
 
   # Create model tree
+  # - Notes about aggFun:
+  #  - identity is not the same as base::identity. collapsibleTree has specific
+  #  handling for `aggFun = identity`, and it's the only way for sizing to work
+  #  based on a column without aggregating values.
+  #  - Note: The node sizing logic has a known quirk where it appears to scale
+  #  sizes relative to the first "parent" node (i.e., the first row where `from`
+  #  is not NA). This can cause inconsistencies in relative node sizes depending
+  #  on the value of the first parent node.
   pl_tree <- collapsibleTree::collapsibleTreeNetwork(
     tree_data, zoomable = zoomable, collapsed = FALSE,
     # Coloring and sizing

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -169,6 +169,7 @@ model_tree.bbi_log_df <- function(
   stop_if_tree_missing_deps(static = static)
 
   # Make tree data
+  include_info <- unique(c(include_info, color_by, size_by))
   tree_data <- make_tree_data(.log_df, include_info, color_by, size_by, add_summary)
 
   # Format coloring

--- a/R/model-tree.R
+++ b/R/model-tree.R
@@ -179,15 +179,17 @@ model_tree.bbi_log_df <- function(
 
   # Format sizing
   tree_data <- size_tree_by(tree_data, size_by = size_by)
+  node_size <- ifelse(is.null(size_by), "leafCount", "node_size")
 
   # Compile attributes into tooltip
   tree_data <- make_tree_tooltip(tree_data, digits = digits)
 
   # Create model tree
   pl_tree <- collapsibleTree::collapsibleTreeNetwork(
-    tree_data, zoomable = zoomable, attribute = tree_attr,
-    fill="col", collapsed = FALSE, nodeSize = "node_size",
-    aggFun = identity,
+    tree_data, zoomable = zoomable, collapsed = FALSE,
+    # Coloring and sizing
+    attribute = tree_attr, fill="col", nodeSize = node_size, aggFun = identity,
+    # Tooltip and display
     tooltipHtml = "tooltip", width = width, height = height
   )
 

--- a/man/make_tree_data.Rd
+++ b/man/make_tree_data.Rd
@@ -8,18 +8,23 @@ make_tree_data(
   .log_df,
   include_info = c("description", "star", "tags"),
   color_by = "run",
+  size_by = NULL,
   add_summary = TRUE
 )
 }
 \arguments{
 \item{.log_df}{a \code{bbr} run log}
 
-\item{include_info}{vector of columns present in \code{.log_df} to include in the
+\item{include_info}{A vector of columns present in \code{.log_df} to include in the
 tooltip.}
 
-\item{color_by}{a run log column to color the nodes by. Can be helpful for
+\item{color_by}{A run log column to color the nodes by. Can be helpful for
 identifying which models are starred, have heuristics, etc. See details
 for more information.}
+
+\item{size_by}{A run log column to size the nodes by. Can be helpful for
+sizing nodes by objective function values or otherwise emphasizing
+notable differences in numeric columns. See details for more information.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}

--- a/man/make_tree_data.Rd
+++ b/man/make_tree_data.Rd
@@ -23,8 +23,8 @@ identifying which models are starred, have heuristics, etc. See details
 for more information.}
 
 \item{size_by}{A \strong{numeric} (or integer) run log column to size the nodes by.
-If not specified, the default sizing is \code{'leafCount'}, which sizes the
-nodes based on how many models are based on it.}
+If not specified, the default is to size the nodes based on how many
+models are based on it.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}

--- a/man/make_tree_data.Rd
+++ b/man/make_tree_data.Rd
@@ -23,8 +23,8 @@ identifying which models are starred, have heuristics, etc. See details
 for more information.}
 
 \item{size_by}{A \strong{numeric} (or integer) run log column to size the nodes by.
-Can be helpful for sizing nodes by objective function values or
-otherwise emphasizing notable differences in numeric columns.}
+If not specified, the default sizing is \code{'leafCount'}, which sizes the
+nodes based on how many models are based on it.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}

--- a/man/make_tree_data.Rd
+++ b/man/make_tree_data.Rd
@@ -22,9 +22,9 @@ tooltip.}
 identifying which models are starred, have heuristics, etc. See details
 for more information.}
 
-\item{size_by}{A run log column to size the nodes by. Can be helpful for
-sizing nodes by objective function values or otherwise emphasizing
-notable differences in numeric columns. See details for more information.}
+\item{size_by}{A \strong{numeric} (or integer) run log column to size the nodes by.
+Can be helpful for sizing nodes by objective function values or
+otherwise emphasizing notable differences in numeric columns.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}

--- a/man/model_tree.Rd
+++ b/man/model_tree.Rd
@@ -30,9 +30,9 @@ tooltip.}
 identifying which models are starred, have heuristics, etc. See details
 for more information.}
 
-\item{size_by}{A run log column to size the nodes by. Can be helpful for
-sizing nodes by objective function values or otherwise emphasizing
-notable differences in numeric columns. See details for more information.}
+\item{size_by}{A \strong{numeric} (or integer) run log column to size the nodes by.
+Can be helpful for sizing nodes by objective function values or
+otherwise emphasizing notable differences in numeric columns.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}
@@ -95,8 +95,8 @@ formatted specially:
 \item Note that the above summary columns will only receive the special
 formatting if added via \code{add_summary = TRUE}.
 \item i.e. if \code{.log_df = run_log() \%>\% add_summary()} and
-\code{include_info = 'ofv'}, The \code{'OFV'} parameter will be formatted as any
-other additional column.
+\code{include_info = 'ofv'}, The \code{'OFV'} parameter will display the same as if
+it was \emph{not} passed to \code{include_info}.
 }
 }
 
@@ -107,13 +107,6 @@ Nodes will be colored \code{'white'} for \code{FALSE} and \code{'red'} for \code
 column types will be colored via a gradient between \code{'white'} and \code{'red'},
 where earlier runs are whiter, and later runs appear to be more red. You can
 pass \code{color_by = NULL} to make all model nodes \code{'red'}.
-
-\strong{Sizing}
-
-Sizing is intended to be used for numeric columns (such as \code{'ofv'} when
-\code{.log_df = run_log() \%>\% add_summary()}). Logical columns are supported, though
-you may experience different sizing behavior depending on the occurrence of
-\code{TRUE}/\code{FALSE} values in the run log.
 }
 
 \examples{
@@ -132,7 +125,7 @@ model_tree(MODEL_DIR, color_by = "star")
 
 # Size nodes by objective function value
 run_log(MODEL_DIR) \%>\% add_summary() \%>\%
-  model_tree(size_by = "ofv")
+  model_tree(size_by = "ofv", color_by = "ofv")
 
 # Determine if certain models need to be re-run
 run_log(MODEL_DIR) \%>\% add_config() \%>\%

--- a/man/model_tree.Rd
+++ b/man/model_tree.Rd
@@ -15,6 +15,7 @@ model_tree(
   static = FALSE,
   width = NULL,
   height = NULL,
+  font_size = 10,
   ...
 )
 }
@@ -49,6 +50,8 @@ be saved as a PNG and loaded into the viewer.}
 \item{width}{Width in pixels (optional, defaults to automatic sizing)}
 
 \item{height}{Height in pixels (optional, defaults to automatic sizing)}
+
+\item{font_size}{Font size of the label text in pixels}
 
 \item{...}{Additional arguments passed to \code{\link[=run_log]{run_log()}}. Only used if \code{.log_df}
 is a modeling directory.}

--- a/man/model_tree.Rd
+++ b/man/model_tree.Rd
@@ -31,8 +31,8 @@ identifying which models are starred, have heuristics, etc. See details
 for more information.}
 
 \item{size_by}{A \strong{numeric} (or integer) run log column to size the nodes by.
-Can be helpful for sizing nodes by objective function values or
-otherwise emphasizing notable differences in numeric columns.}
+If not specified, the default sizing is \code{'leafCount'}, which sizes the
+nodes based on how many models are based on it.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}

--- a/man/model_tree.Rd
+++ b/man/model_tree.Rd
@@ -2,40 +2,13 @@
 % Please edit documentation in R/model-tree.R
 \name{model_tree}
 \alias{model_tree}
-\alias{model_tree.character}
-\alias{model_tree.bbi_log_df}
 \title{Create a tree diagram of a modeling directory}
 \usage{
 model_tree(
   .log_df,
   include_info = c("description", "star", "tags"),
   color_by = "run",
-  add_summary = TRUE,
-  digits = 3,
-  zoomable = FALSE,
-  static = FALSE,
-  width = NULL,
-  height = NULL,
-  ...
-)
-
-\method{model_tree}{character}(
-  .log_df,
-  include_info = c("description", "star", "tags"),
-  color_by = "run",
-  add_summary = TRUE,
-  digits = 3,
-  zoomable = FALSE,
-  static = FALSE,
-  width = NULL,
-  height = NULL,
-  ...
-)
-
-\method{model_tree}{bbi_log_df}(
-  .log_df,
-  include_info = c("description", "star", "tags"),
-  color_by = "run",
+  size_by = NULL,
   add_summary = TRUE,
   digits = 3,
   zoomable = FALSE,
@@ -46,15 +19,19 @@ model_tree(
 )
 }
 \arguments{
-\item{.log_df}{a \code{bbi_run_log_df} tibble (the output of \code{run_log()}) \emph{\strong{or}}
+\item{.log_df}{A \code{bbi_run_log_df} tibble (the output of \code{run_log()}) \emph{\strong{or}}
 a base directory to look in for models. See details for more options.}
 
-\item{include_info}{vector of columns present in \code{.log_df} to include in the
+\item{include_info}{A vector of columns present in \code{.log_df} to include in the
 tooltip.}
 
-\item{color_by}{a run log column to color the nodes by. Can be helpful for
+\item{color_by}{A run log column to color the nodes by. Can be helpful for
 identifying which models are starred, have heuristics, etc. See details
 for more information.}
+
+\item{size_by}{A run log column to size the nodes by. Can be helpful for
+sizing nodes by objective function values or otherwise emphasizing
+notable differences in numeric columns. See details for more information.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}
@@ -69,11 +46,11 @@ dragging and scrolling.}
 static image. This takes a little longer, as the interactive plot must
 be saved as a PNG and loaded into the viewer.}
 
-\item{width}{width in pixels (optional, defaults to automatic sizing)}
+\item{width}{Width in pixels (optional, defaults to automatic sizing)}
 
-\item{height}{height in pixels (optional, defaults to automatic sizing)}
+\item{height}{Height in pixels (optional, defaults to automatic sizing)}
 
-\item{...}{additional arguments passed to \code{\link[=run_log]{run_log()}}. Only used if \code{.log_df}
+\item{...}{Additional arguments passed to \code{\link[=run_log]{run_log()}}. Only used if \code{.log_df}
 is a modeling directory.}
 }
 \description{
@@ -96,7 +73,7 @@ additional columns as tooltips. This is illustrated in the examples via
 \code{add_summary()} and \code{add_config()}.
 }
 
-\section{Tooltip formatting and coloring}{
+\section{Tooltip formatting, coloring, and sizing}{
 
 \strong{Tooltip formatting}
 
@@ -127,6 +104,13 @@ Nodes will be colored \code{'white'} for \code{FALSE} and \code{'red'} for \code
 column types will be colored via a gradient between \code{'white'} and \code{'red'},
 where earlier runs are whiter, and later runs appear to be more red. You can
 pass \code{color_by = NULL} to make all model nodes \code{'red'}.
+
+\strong{Sizing}
+
+Sizing is intended to be used for numeric columns (such as \code{'ofv'} when
+\code{.log_df = run_log() \%>\% add_summary()}). Logical columns are supported, though
+you may experience different sizing behavior depending on the occurrence of
+\code{TRUE}/\code{FALSE} values in the run log.
 }
 
 \examples{
@@ -140,19 +124,27 @@ run_log(MODEL_DIR) \%>\% model_tree()
 model_tree(MODEL_DIR, color_by = "star")
 
 
-# Run `add_config()`, `add_summary()`, and/or `mutate()` calls beforehand
-run_log(MODEL_DIR) \%>\%
-  add_config() \%>\%
-  dplyr::mutate(out_of_date = model_has_changed | data_has_changed) \%>\%
+## Run `add_config()`, `add_summary()`, and/or `mutate()` calls beforehand
+
+
+# Size nodes by objective function value
+run_log(MODEL_DIR) \%>\% add_summary() \%>\%
+  model_tree(size_by = "ofv")
+
+# Determine if certain models need to be re-run
+run_log(MODEL_DIR) \%>\% add_config() \%>\%
+  dplyr::mutate(
+    out_of_date = model_has_changed | data_has_changed
+  ) \%>\%
   model_tree(
     include_info = c("model_has_changed", "data_has_changed", "nm_version"),
     color_by = "out_of_date"
   )
 
-run_log(MODEL_DIR) \%>\%
-  add_summary() \%>\%
+# Highlight models with any heuristics
+run_log(MODEL_DIR) \%>\% add_summary() \%>\%
   model_tree(
-    include_info = c("tags", "param_count", "eta_pval_significant"),
+    include_info = c("param_count", "eta_pval_significant"),
     color_by = "any_heuristics"
   )
 

--- a/man/model_tree.Rd
+++ b/man/model_tree.Rd
@@ -31,8 +31,8 @@ identifying which models are starred, have heuristics, etc. See details
 for more information.}
 
 \item{size_by}{A \strong{numeric} (or integer) run log column to size the nodes by.
-If not specified, the default sizing is \code{'leafCount'}, which sizes the
-nodes based on how many models are based on it.}
+If not specified, the default is to size the nodes based on how many
+models are based on it.}
 
 \item{add_summary}{Logical (\code{TRUE}/\code{FALSE}). If \code{TRUE}, include key columns
 from \code{\link[=model_summary]{model_summary()}} output.}
@@ -95,7 +95,7 @@ formatted specially:
 \item Note that the above summary columns will only receive the special
 formatting if added via \code{add_summary = TRUE}.
 \item i.e. if \code{.log_df = run_log() \%>\% add_summary()} and
-\code{include_info = 'ofv'}, The \code{'OFV'} parameter will display the same as if
+\code{include_info = 'ofv'}, the \code{'OFV'} parameter will display the same as if
 it was \emph{not} passed to \code{include_info}.
 }
 }

--- a/tests/testthat/helpers-create-example-model.R
+++ b/tests/testthat/helpers-create-example-model.R
@@ -157,7 +157,8 @@ make_fake_boot <- function(mod, n = 100, strat_cols = c("SEX", "ETN")){
 # Unlike make_fake_boot however, the simulation will have a status of "Not Run"
 make_fake_sim <- function(mod, mod_id = "mod-sim", n = 100){
   mod_sim <- copy_model_from(mod, mod_id) %>% update_model_id()
-  new_dir_path <- file.path(MODEL_DIR, mod_id)
+  model_dir <- get_model_working_directory(MOD1)
+  new_dir_path <- file.path(model_dir, mod_id)
   fs::dir_copy(mod$absolute_model_path, new_dir_path)
   mod_sim <- add_msf_opt(mod_sim)
 

--- a/tests/testthat/helpers-create-example-model.R
+++ b/tests/testthat/helpers-create-example-model.R
@@ -157,7 +157,7 @@ make_fake_boot <- function(mod, n = 100, strat_cols = c("SEX", "ETN")){
 # Unlike make_fake_boot however, the simulation will have a status of "Not Run"
 make_fake_sim <- function(mod, mod_id = "mod-sim", n = 100){
   mod_sim <- copy_model_from(mod, mod_id) %>% update_model_id()
-  model_dir <- get_model_working_directory(mod)
+  model_dir <- bbr:::get_model_working_directory(mod)
   new_dir_path <- file.path(model_dir, mod_id)
   fs::dir_copy(mod$absolute_model_path, new_dir_path)
   mod_sim <- add_msf_opt(mod_sim)

--- a/tests/testthat/helpers-create-example-model.R
+++ b/tests/testthat/helpers-create-example-model.R
@@ -157,7 +157,7 @@ make_fake_boot <- function(mod, n = 100, strat_cols = c("SEX", "ETN")){
 # Unlike make_fake_boot however, the simulation will have a status of "Not Run"
 make_fake_sim <- function(mod, mod_id = "mod-sim", n = 100){
   mod_sim <- copy_model_from(mod, mod_id) %>% update_model_id()
-  model_dir <- get_model_working_directory(MOD1)
+  model_dir <- get_model_working_directory(mod)
   new_dir_path <- file.path(model_dir, mod_id)
   fs::dir_copy(mod$absolute_model_path, new_dir_path)
   mod_sim <- add_msf_opt(mod_sim)

--- a/tests/testthat/test-model-tree.R
+++ b/tests/testthat/test-model-tree.R
@@ -440,14 +440,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
         'Only numeric columns are supported'
       )
       node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
-      expect_true(dplyr::n_distinct(node_sizes) == 1)
+      expect_true(dplyr::n_distinct(node_sizes) == 2) # leafCount sizing
       # Check character
       expect_warning(
         pl_tree <- model_tree(log_df2, add_summary = FALSE, size_by = "star"),
         'Only numeric columns are supported'
       )
       node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
-      expect_true(dplyr::n_distinct(node_sizes) == 1)
+      expect_true(dplyr::n_distinct(node_sizes) == 2) # leafCount sizing
     })
 
     it("static plot", {

--- a/tests/testthat/test-model-tree.R
+++ b/tests/testthat/test-model-tree.R
@@ -388,7 +388,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
       clean_test_enviroment(create_tree_models)
 
       log_df <- run_log(MODEL_DIR) %>% dplyr::mutate(
-        size_col = as.numeric(run)
+        size_col = as.integer(run)
       )
 
       # Checks that the size increases with each node (like size_col, i.e. run number)
@@ -397,37 +397,6 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
       expect_true(all(diff(node_sizes) > 0))
 
       ### Data checks ###
-      # Test logical size_by
-      true_indices <- which(log_df$star)
-      false_indices <- which(!log_df$star)
-      pl_tree <- model_tree(log_df, add_summary = FALSE, size_by = "star")
-      node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
-
-      tree_data <- make_tree_data(log_df, add_summary = FALSE)
-      tree_data_star <- size_tree_by(tree_data, size_by = "star")
-      data_sizes <- tree_data_star$node_size[-1]
-
-      # Checks that the TRUE values are larger than FALSE values
-      # - Checks the underlying data, and rendered node size
-      expect_true(all(node_sizes[true_indices] > node_sizes[false_indices]))
-      expect_true(all(data_sizes[true_indices] > data_sizes[false_indices]))
-
-      # Check if all the same value (works the same if TRUE or NA)
-      log_df2 <- log_df
-      log_df2$star <- FALSE
-      false_indices <- which(!log_df2$star)
-      pl_tree <- model_tree(log_df2, add_summary = FALSE, size_by = "star")
-      node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
-
-      tree_data <- make_tree_data(log_df2, add_summary = FALSE)
-      tree_data_star <- size_tree_by(tree_data, size_by = "star")
-      data_sizes <- tree_data_star$node_size[-1]
-
-      # Checks that all values are the same size
-      # - Checks the underlying data, and rendered node size
-      expect_true(dplyr::n_distinct(node_sizes[false_indices]) == 1)
-      expect_true(dplyr::n_distinct(data_sizes[false_indices]) == 1)
-
 
       # Test numeric size_by (gradient sizing) - mimics objective function
       set.seed(1234)
@@ -446,6 +415,39 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
       # - Checks the underlying data, and rendered node size
       expect_equal(order(size_col_vals), order(node_sizes))
       expect_equal(order(size_col_vals), order(data_sizes))
+
+      # Check if all the same value
+      log_df2 <- log_df
+      log_df2$size_col <- 1
+      size_col_vals <- log_df2$size_col
+      pl_tree <- model_tree(log_df2, add_summary = FALSE, size_by = "size_col")
+      node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
+
+      tree_data <- make_tree_data(log_df2, add_summary = FALSE, size_by = "size_col")
+      tree_data_size <- size_tree_by(tree_data, size_by = "size_col")
+      data_sizes <- tree_data_size$node_size[-1]
+
+      # Checks that all values are the same size
+      # - Checks the underlying data, and rendered node size
+      expect_true(dplyr::n_distinct(node_sizes) == 1)
+      expect_true(dplyr::n_distinct(data_sizes) == 1)
+
+      ## Warns if non-numeric (or non-integer) column ##
+      log_df2 <- log_df2 %>% dplyr::mutate(run = as.character(run))
+      # Check logical
+      expect_warning(
+        pl_tree <- model_tree(log_df2, add_summary = FALSE, size_by = "star"),
+        'Only numeric columns are supported'
+      )
+      node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
+      expect_true(dplyr::n_distinct(node_sizes) == 1)
+      # Check character
+      expect_warning(
+        pl_tree <- model_tree(log_df2, add_summary = FALSE, size_by = "star"),
+        'Only numeric columns are supported'
+      )
+      node_sizes <- get_node_attribute(pl_tree$x$data$children, attr = "SizeOfNode")
+      expect_true(dplyr::n_distinct(node_sizes) == 1)
     })
 
     it("static plot", {
@@ -456,6 +458,21 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
       # data is returned
       expect_true(inherits(pl_tree, "model_tree_static"))
       expect_true(inherits(pl_tree$png_array, "array"))
+    })
+
+    it("Check for missing columns", {
+      clean_test_enviroment(create_tree_models)
+      # Required columns are missing
+      log_df <- run_log(MODEL_DIR) %>% dplyr::select(-c("run", "based_on", "model_type"))
+      expect_error(
+        model_tree(log_df, add_summary = FALSE),
+        "columns are missing"
+      )
+      # Specified columns are missing
+      expect_error(
+        model_tree(MODEL_DIR, add_summary = FALSE, include_info = c("oops_I", "did_it_again")),
+        "columns are missing"
+      )
     })
   })
 }) # closing withr::with_options

--- a/tests/testthat/test-model-tree.R
+++ b/tests/testthat/test-model-tree.R
@@ -361,7 +361,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
         c("#007319", rep("#EB003D", 4), "#C0C0C0")
       )
 
-      # Test numeric/character color_by (gradient coloring)
+      # Test character color_by (gradient coloring)
       tree_data <- make_tree_data(run_log(MODEL_DIR), add_summary = FALSE)
       tree_data_run <- color_tree_by(tree_data, color_by = "run")
       expect_equal(
@@ -370,6 +370,18 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
         # Note: all gradient colors will shift if number of models change
         c("#007319", "#FFFFFF", "#F4DBD3", "#ED9D84", "#E35B44", "#EB003D")
       )
+
+      # Regression test: numeric color_by is sorted appropriately
+      log_df <- run_log(MODEL_DIR)
+      log_df$numeric_vals <- c(1534, 3892, 731, 2653, 3574)
+      pl_tree <- model_tree(
+        log_df, add_summary = FALSE, color_by = "numeric_vals",
+        include_info = "numeric_vals"
+      )
+      node_colors <- get_node_attribute(pl_tree$x$data$children, attr = "fill")
+      expected_colors <- c("#F4DBD3", "#EB003D", "#FFFFFF", "#ED9D84", "#E35B44")
+      # Can inspect with `scales::show_col(node_colors)`
+      expect_equal(node_colors, expected_colors)
     })
 
     it("size_tree_by()", {

--- a/tests/testthat/test-model-tree.R
+++ b/tests/testthat/test-model-tree.R
@@ -382,6 +382,17 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
       expected_colors <- c("#F4DBD3", "#EB003D", "#FFFFFF", "#ED9D84", "#E35B44")
       # Can inspect with `scales::show_col(node_colors)`
       expect_equal(node_colors, expected_colors)
+
+      # Check integer case
+      log_df$numeric_vals <- as.integer(log_df$numeric_vals)
+      pl_tree <- model_tree(
+        log_df, add_summary = FALSE, color_by = "numeric_vals",
+        include_info = "numeric_vals"
+      )
+      node_colors <- get_node_attribute(pl_tree$x$data$children, attr = "fill")
+      expected_colors <- c("#F4DBD3", "#EB003D", "#FFFFFF", "#ED9D84", "#E35B44")
+      # Can inspect with `scales::show_col(node_colors)`
+      expect_equal(node_colors, expected_colors)
     })
 
     it("size_tree_by()", {

--- a/tests/testthat/test-model-tree.R
+++ b/tests/testthat/test-model-tree.R
@@ -23,18 +23,18 @@ count_nodes <- function(tree_list) {
 
 # Get node attribute for each model
 get_node_attribute <- function(tree_list, attr = 'SizeOfNode') {
-  if (length(tree_list) == 0) return(numeric(0))
+  if(length(tree_list) == 0) return(numeric(0))
   # Iterate through each element in the list
   attribute_values <- numeric(0)
-  for (i in seq_along(tree_list)) {
+  for(i in seq_along(tree_list)) {
     # Check if the specified attribute exists in the current node
-    if (!is.null(tree_list[[i]][[attr]])) {
+    if(!is.null(tree_list[[i]][[attr]])){
       attr_value <- tree_list[[i]][[attr]]
       if(is.factor(attr_value)) attr_value <- as.character(attr_value)
       attribute_values <- c(attribute_values, attr_value)
     }
     # If the current node has children, recursively get the attribute from children
-    if (length(tree_list[[i]]$children) > 0) {
+    if(length(tree_list[[i]]$children) > 0){
       attribute_values <- c(attribute_values, get_node_attribute(tree_list[[i]]$children, attr))
     }
   }
@@ -430,6 +430,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
 
       # Test numeric size_by (gradient sizing) - mimics objective function
+      set.seed(1234)
       log_df <- log_df %>% dplyr::mutate(
         size_col = abs(rnorm(nrow(log_df), mean = 1500, sd = 800))
       )

--- a/vignettes/model-tree.Rmd
+++ b/vignettes/model-tree.Rmd
@@ -172,7 +172,7 @@ In this example we define a new column, `out_of_date`, to denote whether the mod
 log_df %>% add_config() %>%
   dplyr::mutate(out_of_date = model_has_changed | data_has_changed) %>%
   model_tree(
-    include_info = c("model_has_changed", "data_has_changed", "nm_version"),
+    include_info = c("model_has_changed", "data_has_changed"),
     color_by = "out_of_date"
   )
 ```
@@ -219,20 +219,18 @@ model_tree(
 
 ## Size the nodes by a particular column
 
-Controlling the node size can be helpful for quickly determining the trend of a particular numeric column, or further emphasizing a logical one (e.g., `'star'`). Here, we use `color_by` and `size_by` to show the objective function value decreasing with each new model.
+Controlling the node size can be helpful for quickly determining the trend of a particular **numeric** column. Here, we use `color_by` and `size_by` to show the objective function value decreasing with each new model.
+
  - **Note:** Like the `color_by` argument, only columns included in `log_df` can be passed. We have to call `add_summary()` to use `"ofv"` even though this is included in the tooltip when `add_summary = TRUE`.
+ - If `size_by` is _not_ specified, the nodes are sized based on how many other models/nodes stem from it (i.e. the "final model" will be smaller than the "base model").
 ```{r, eval=FALSE}
 log_df %>% add_summary() %>%
-  model_tree(
-    include_info = c("star", "description"),
-    color_by = "ofv", size_by = "ofv"
-  )
+  model_tree(color_by = "ofv", size_by = "ofv")
 ```
 
 ```{r, echo=FALSE, eval=eval_model_tree}
 model_tree(
   log_df,
-  include_info = c("star", "description"),
   color_by = "ofv", size_by = "ofv",
   width = 800,
   font_size = 12

--- a/vignettes/model-tree.Rmd
+++ b/vignettes/model-tree.Rmd
@@ -132,7 +132,7 @@ model_tree(MODEL_DIR)
 ```{r, echo=FALSE, eval=eval_model_tree}
 # you dont need to specify the width when rendering in Rstudio viewer, but it makes a difference when rendered in Rmarkdown 
 # - relying on auto-sizing leads to a plot with a small width
-model_tree(MODEL_DIR, width = 800)
+model_tree(MODEL_DIR, width = 800, font_size = 12)
 ```
 
 
@@ -144,7 +144,7 @@ model_tree(MODEL_DIR, color_by = "star")
 ```
 
 ```{r, echo=FALSE, eval=eval_model_tree}
-model_tree(MODEL_DIR, color_by = "star", width = 800)
+model_tree(MODEL_DIR, color_by = "star", width = 800, font_size = 12)
 ```
 
 
@@ -158,7 +158,8 @@ log_df
 log_df <- run_log(MODEL_DIR) %>% add_summary() %>% add_config() %>% suppressWarnings()
 ofv_nas <- which(is.na(log_df$ofv))
 # Overwrite ofv to reflect a typical modeling workflow
-log_df$ofv <- sort(abs(rnorm(nrow(log_df), mean = 2600, sd = 900)), decreasing = TRUE)
+set.seed(1234)
+log_df$ofv <- sort(abs(rnorm(nrow(log_df), mean = 2600, sd = 500)), decreasing = TRUE)
 # Make the "final model" the smallest ofv instead of the last one in the run log
 log_df$ofv[log_df$description == "final model"] <- min(log_df$ofv, na.rm = TRUE)
 log_df$ofv[nrow(log_df)] <- min(log_df$ofv, na.rm = TRUE)*1.1
@@ -188,7 +189,8 @@ model_tree(
   log_df2,
   include_info = c("model_has_changed", "data_has_changed", "nm_version"),
   color_by = "out_of_date",
-  width = 800
+  width = 800,
+  font_size = 12
 )
 ```
 
@@ -210,7 +212,8 @@ model_tree(
   log_df2,
   include_info = c("tags", "param_count", "eta_pval_significant"),
   color_by = "any_heuristics",
-  width = 800
+  width = 800,
+  font_size = 12
 )
 ```
 
@@ -231,7 +234,8 @@ model_tree(
   log_df,
   include_info = c("star", "description"),
   color_by = "ofv", size_by = "ofv",
-  width = 800
+  width = 800,
+  font_size = 12
 )
 ```
 

--- a/vignettes/model-tree.Rmd
+++ b/vignettes/model-tree.Rmd
@@ -135,6 +135,9 @@ model_tree(MODEL_DIR)
 model_tree(MODEL_DIR, width = 800)
 ```
 
+
+## Adjust the coloring and tooltip
+
 If coloring by a logical column, `FALSE` and `TRUE` values will correspond to white and red coloring respectively. Numeric or character columns will be colored as a gradient. `NA` values will appear grey regardless of the column type.
 ```{r, eval=FALSE}
 model_tree(MODEL_DIR, color_by = "star")
@@ -151,10 +154,21 @@ log_df <- run_log(MODEL_DIR)
 log_df
 ```
 
+```{r, echo=FALSE, eval=eval_model_tree}
+log_df <- run_log(MODEL_DIR) %>% add_summary() %>% add_config() %>% suppressWarnings()
+ofv_nas <- which(is.na(log_df$ofv))
+# Overwrite ofv to reflect a typical modeling workflow
+log_df$ofv <- sort(abs(rnorm(nrow(log_df), mean = 2600, sd = 900)), decreasing = TRUE)
+# Make the "final model" the smallest ofv instead of the last one in the run log
+log_df$ofv[log_df$description == "final model"] <- min(log_df$ofv, na.rm = TRUE)
+log_df$ofv[nrow(log_df)] <- min(log_df$ofv, na.rm = TRUE)*1.1
+# retain existing NAs of objective function (mainly for bootstrap example)
+log_df$ofv[ofv_nas] <- NA 
+```
+
 In this example we define a new column, `out_of_date`, to denote whether the model or data has changed since the last run. We can color by this new column to determine if any of the models need to be re-run:
 ```{r, eval=FALSE}
-run_log(MODEL_DIR) %>%
-  add_config() %>%
+log_df %>% add_config() %>%
   dplyr::mutate(out_of_date = model_has_changed | data_has_changed) %>%
   model_tree(
     include_info = c("model_has_changed", "data_has_changed", "nm_version"),
@@ -164,22 +178,23 @@ run_log(MODEL_DIR) %>%
 
 ```{r, echo=FALSE, eval=eval_model_tree}
 # Since using fake model runs (appearing out of date), set most to FALSE
-log_df <- run_log(MODEL_DIR) %>% add_config() %>% suppressWarnings()
-log_df$model_has_changed[2:7] <- FALSE
+log_df2 <- log_df
+log_df2$model_has_changed[2:7] <- FALSE
+log_df2 <- log_df2 %>% dplyr::mutate(
+  out_of_date = model_has_changed | data_has_changed
+)
 
-log_df %>% 
-  dplyr::mutate(out_of_date = model_has_changed | data_has_changed) %>%
-  model_tree(
-    include_info = c("model_has_changed", "data_has_changed", "nm_version"),
-    color_by = "out_of_date",
-    width = 800
-  )
+model_tree(
+  log_df2,
+  include_info = c("model_has_changed", "data_has_changed", "nm_version"),
+  color_by = "out_of_date",
+  width = 800
+)
 ```
 
 The model tree can also be helpful for quickly determine if any heuristics were found during any model submissions, as well as displaying specific model summary output in the tooltip. 
 ```{r, eval=FALSE}
-run_log(MODEL_DIR) %>%
-  add_summary() %>%
+log_df %>% add_summary() %>%
   model_tree(
     include_info = c("tags", "param_count", "eta_pval_significant"),
     color_by = "any_heuristics"
@@ -188,12 +203,34 @@ run_log(MODEL_DIR) %>%
 
 ```{r, echo=FALSE, eval=eval_model_tree}
 # Since using fake models (all inheriting the same issues), set some to FALSE
-log_df <- run_log(MODEL_DIR) %>% add_summary()
-log_df$any_heuristics[c(5, 7, 9)] <- FALSE
+log_df2 <- log_df
+log_df2$any_heuristics[c(5, 7, 9)] <- FALSE
+
 model_tree(
-  log_df,
+  log_df2,
   include_info = c("tags", "param_count", "eta_pval_significant"),
   color_by = "any_heuristics",
+  width = 800
+)
+```
+
+## Size the nodes by a particular column
+
+Controlling the node size can be helpful for quickly determining the trend of a particular numeric column, or further emphasizing a logical one (e.g., `'star'`). Here, we use `color_by` and `size_by` to show the objective function value decreasing with each new model.
+ - **Note:** Like the `color_by` argument, only columns included in `log_df` can be passed. We have to call `add_summary()` to use `"ofv"` even though this is included in the tooltip when `add_summary = TRUE`.
+```{r, eval=FALSE}
+log_df %>% add_summary() %>%
+  model_tree(
+    include_info = c("star", "description"),
+    color_by = "ofv", size_by = "ofv"
+  )
+```
+
+```{r, echo=FALSE, eval=eval_model_tree}
+model_tree(
+  log_df,
+  include_info = c("star", "description"),
+  color_by = "ofv", size_by = "ofv",
   width = 800
 )
 ```


### PR DESCRIPTION
### Core new feature: `size_by`
 - Allows users to control the node sizing by a particular column present in `.log_df`

 - Important to note that `ofv` cant be used without first calling `add_summary()`, which is consistent with the previous behavior of `color_by` and `include_info`.

 - This argument *does* support logical columns, however I noticed that the normalized sizing can differ here depending when the first `TRUE` value originates. If it's the first value, all the nodes appear smaller. Anywhere else and the "base size" is larger. This observation is likely true for numeric columns too, though is less apparent when the values are all closer to each other.
    -  We may want to revisit NA values for numeric columns

![image](https://github.com/user-attachments/assets/42a10ef9-0e9a-4152-a5a6-42a01611f7d1)

### Other changes

 - Fixed a bug when coloring numeric columns. See details in [6d11e25](https://github.com/metrumresearchgroup/bbr/pull/720/commits/6d11e25bb779282ff79c040037bf413790384b21)
 - Added `font_size` argument. While updating the vignette I foresaw a future request to adjust this, and it was easy enough to pass to `collapsibleTree::collapsibleTreeNetwork` (with one other change)
    - Was later requested by @callistosp 
 - Updated vignette with new example
 - Formatting fix: dont display tooltips for 'start' node ([fc65532](https://github.com/metrumresearchgroup/bbr/pull/720/commits/fc65532169cb5c31a13e11c291cd8e0f63bb0bb5))
 - Css simplifications and other minor adjustments
