### PR TITLE
Add submission mode for Slurm

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -98,5 +98,5 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 SystemRequirements: bbi (>= 3.0.2)

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -5,7 +5,7 @@ BBI_DEFAULT_PATH <- if (ON_WINDOWS) {
   "bbi"
 }
 
-BBI_VALID_MODES <- c("local", "sge")
+BBI_VALID_MODES <- c("local", "sge", "slurm")
 
 CACHE_ENV <- new.env(parent = emptyenv())
 CACHE_ENV$bbi_exe_paths <- list()

--- a/man/simulate.Rd
+++ b/man/simulate.Rd
@@ -60,9 +60,9 @@ formatted like \code{list("nm_version" = "nm74gf_nmfe", "json" = T, "threads" = 
 not support changing the output directory (including through the model or
 global YAML files).}
 
-\item{.mode}{Either \code{"sge"}, the default, to submit model(s) to the grid or
-\code{"local"} for local execution. This can be passed directly to this argument
-or set globally with \code{options("bbr.bbi_exe_mode")}.}
+\item{.mode}{Mode for model submission: "local", "sge", or "slurm". If
+unspecified, the value is set to the value of the \code{bbr.bbi_exe_mode}
+option. This option defaults to "sge" on Linux and "local" otherwise.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
 

--- a/man/submit_model.Rd
+++ b/man/submit_model.Rd
@@ -60,9 +60,9 @@ formatted like \code{list("nm_version" = "nm74gf_nmfe", "json" = T, "threads" = 
 not support changing the output directory (including through the model or
 global YAML files).}
 
-\item{.mode}{Either \code{"sge"}, the default, to submit model(s) to the grid or
-\code{"local"} for local execution. This can be passed directly to this argument
-or set globally with \code{options("bbr.bbi_exe_mode")}.}
+\item{.mode}{Mode for model submission: "local", "sge", or "slurm". If
+unspecified, the value is set to the value of the \code{bbr.bbi_exe_mode}
+option. This option defaults to "sge" on Linux and "local" otherwise.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
 

--- a/man/submit_models.Rd
+++ b/man/submit_models.Rd
@@ -35,9 +35,9 @@ formatted like \code{list("nm_version" = "nm74gf_nmfe", "json" = T, "threads" = 
 not support changing the output directory (including through the model or
 global YAML files).}
 
-\item{.mode}{Either \code{"sge"}, the default, to submit model(s) to the grid or
-\code{"local"} for local execution. This can be passed directly to this argument
-or set globally with \code{options("bbr.bbi_exe_mode")}.}
+\item{.mode}{Mode for model submission: "local", "sge", or "slurm". If
+unspecified, the value is set to the value of the \code{bbr.bbi_exe_mode}
+option. This option defaults to "sge" on Linux and "local" otherwise.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
 

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -38,6 +38,8 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     fs::dir_create(temp_dir)
     on.exit(fs::dir_delete(temp_dir))
 
+    withr::local_options(list(bbr.DEV_skip_system_mode_checks = TRUE))
+
     readr::write_file("created_by: test-print", file.path(temp_dir, "bbi.yaml"))
 
     mods <- purrr::map(1:50, ~copy_model_from(MOD1, file.path("print-test", .x)))

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -1,4 +1,4 @@
-context("submit_model(.dry_run=T)")
+context("submit_model(.dry_run=TRUE)")
 
 ###################################
 # testing single model submission
@@ -18,18 +18,18 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   cmd_prefix <- paste("cd", model_dir, ";",
                       read_bbi_path(), "nonmem", "run",
                       default_mode)
-  test_that("submit_model(.dry_run=T) returns correct command string [BBR-SBMT-001]",
+  test_that("submit_model(.dry_run=TRUE) returns correct command string [BBR-SBMT-001]",
             {
 
               # correctly parsing yaml
               expect_identical(
-                submit_model(MOD1, .dry_run = T)[[PROC_CALL]],
+                submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
                 as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
               )
 
               # switch to local mode
               expect_identical(
-                submit_model(MOD1, .mode = "local", .dry_run = T)[[PROC_CALL]],
+                submit_model(MOD1, .mode = "local", .dry_run = TRUE)[[PROC_CALL]],
                 as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run local {mod_ctl_path} --overwrite --threads=4 --parallel"))
               )
 
@@ -37,26 +37,26 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               expect_identical(
                 submit_model(MOD1,
                              .bbi_args=list(
-                               "json" = T,
+                               "json" = TRUE,
                                "threads" = 2,
                                "nm_version" = "nm74"
                              ),
-                             .dry_run = T)[[PROC_CALL]],
+                             .dry_run = TRUE)[[PROC_CALL]],
                 as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --json --nm_version=nm74 --parallel"))
               )
             })
 
-  test_that("submit_model(.dry_run=T) with bbi_nonmem_model object parses correctly [BBR-SBMT-002]",
+  test_that("submit_model(.dry_run=TRUE) with bbi_nonmem_model object parses correctly [BBR-SBMT-002]",
             {
               # correctly parsing yaml
               expect_identical(
-                submit_model(MOD1, .dry_run = T)[[PROC_CALL]],
+                submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
                 as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
               )
 
               # over-riding yaml arg with passed arg
               expect_identical(
-                submit_model(MOD1, list(threads=2), .dry_run = T)[[PROC_CALL]],
+                submit_model(MOD1, list(threads=2), .dry_run = TRUE)[[PROC_CALL]],
                 as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --parallel"))
               )
             })
@@ -92,7 +92,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     other_mode <- switch(default_mode, sge = "local", "sge")
     withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
       expect_identical(
-        submit_model(MOD1, .dry_run = T)[[PROC_CALL]],
+        submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
         as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
       )
     })
@@ -101,7 +101,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   test_that("submit_model(.mode) errors when NULL [BBR-SBMT-006]", {
     withr::with_options(list(bbr.bbi_exe_mode = NULL), {
       expect_error(
-        submit_model(MOD1, .dry_run = T),
+        submit_model(MOD1, .dry_run = TRUE),
         regexp = "Nothing was passed.+mode"
       )
     })
@@ -109,7 +109,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
 
   test_that("submit_model(.mode) errors when invalid [BBR-SBMT-007]", {
     expect_error(
-      submit_model(MOD1, .dry_run = T, .mode = "naw"),
+      submit_model(MOD1, .dry_run = TRUE, .mode = "naw"),
       regexp = "Invalid value passed.+mode"
     )
   })

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -72,7 +72,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_identical(
       res[[PROC_CALL]],
       as.character(
-        glue::glue(
+        glue(
           "{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel",
           "--config={temp_config}",
           .sep = " "

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -4,114 +4,114 @@ context("submit_model(.dry_run=TRUE)")
 # testing single model submission
 ###################################
 
-
-
 model_dir <- ABS_MODEL_DIR
 mod_ctl_path <- file.path(model_dir, CTL_FILENAME)
 
 # create fake bbi.yaml
 readr::write_file("created_by: test-submit-model", file.path(model_dir, "bbi.yaml"))
-on.exit({ fs::file_delete(file.path(model_dir, "bbi.yaml"))})
+on.exit(fs::file_delete(file.path(model_dir, "bbi.yaml")))
 
-withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
-  default_mode <- getOption("bbr.bbi_exe_mode")
-  cmd_prefix <- paste("cd", model_dir, ";",
-                      read_bbi_path(), "nonmem", "run",
-                      default_mode)
-  test_that("submit_model(.dry_run=TRUE) returns correct command string",
-            {
+default_mode <- getOption("bbr.bbi_exe_mode")
+cmd_prefix <- paste(
+  "cd", model_dir, ";",
+  read_bbi_path(), "nonmem", "run",
+  default_mode
+)
 
-              # correctly parsing yaml
-              expect_identical(
-                submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
-                as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
-              )
+withr::local_options(list(bbr.bbi_exe_path = read_bbi_path()))
 
-              # switch to local mode
-              expect_identical(
-                submit_model(MOD1, .mode = "local", .dry_run = TRUE)[[PROC_CALL]],
-                as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run local {mod_ctl_path} --overwrite --threads=4 --parallel"))
-              )
+test_that("submit_model(.dry_run=TRUE) returns correct command string", {
+  # correctly parsing yaml
+  expect_identical(
+    submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
+    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
+  )
 
-              # over-riding yaml arg with passed args
-              expect_identical(
-                submit_model(MOD1,
-                             .bbi_args=list(
-                               "json" = TRUE,
-                               "threads" = 2,
-                               "nm_version" = "nm74"
-                             ),
-                             .dry_run = TRUE)[[PROC_CALL]],
-                as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --json --nm_version=nm74 --parallel"))
-              )
-            })
+  # switch to local mode
+  expect_identical(
+    submit_model(MOD1, .mode = "local", .dry_run = TRUE)[[PROC_CALL]],
+    as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run local {mod_ctl_path} --overwrite --threads=4 --parallel"))
+  )
 
-  test_that("submit_model(.dry_run=TRUE) with bbi_nonmem_model object parses correctly",
-            {
-              # correctly parsing yaml
-              expect_identical(
-                submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
-                as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
-              )
+  # over-riding yaml arg with passed args
+  expect_identical(
+    submit_model(MOD1,
+      .bbi_args = list(
+        "json" = TRUE,
+        "threads" = 2,
+        "nm_version" = "nm74"
+      ),
+      .dry_run = TRUE
+    )[[PROC_CALL]],
+    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --json --nm_version=nm74 --parallel"))
+  )
+})
 
-              # over-riding yaml arg with passed arg
-              expect_identical(
-                submit_model(MOD1, list(threads=2), .dry_run = TRUE)[[PROC_CALL]],
-                as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --parallel"))
-              )
-            })
+test_that("submit_model(.dry_run=TRUE) with bbi_nonmem_model object parses correctly", {
+  # correctly parsing yaml
+  expect_identical(
+    submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
+    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
+  )
 
-  test_that("submit_model() creates correct call for non-NULL .config_path", {
+  # over-riding yaml arg with passed arg
+  expect_identical(
+    submit_model(MOD1, list(threads = 2), .dry_run = TRUE)[[PROC_CALL]],
+    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --parallel"))
+  )
+})
 
-    temp_config <- tempfile(fileext = ".yaml")
-    readr::write_file("foo", temp_config)
-    temp_config <- normalizePath(temp_config)
-    on.exit(fs::file_delete(temp_config))
+test_that("submit_model() creates correct call for non-NULL .config_path", {
+  temp_config <- tempfile(fileext = ".yaml")
+  readr::write_file("foo", temp_config)
+  temp_config <- normalizePath(temp_config)
+  on.exit(fs::file_delete(temp_config))
 
-    res <- submit_model(MOD1, .config_path = temp_config, .dry_run = TRUE)
+  res <- submit_model(MOD1, .config_path = temp_config, .dry_run = TRUE)
+  expect_identical(
+    res[[PROC_CALL]],
+    as.character(
+      glue(
+        "{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel",
+        "--config={temp_config}",
+        .sep = " "
+      )
+    )
+  )
+})
+
+test_that("submit_model() throws an error if passed `output_dir` bbi arg", {
+  expect_error(
+    submit_model(MOD1, .bbi_args = list(output_dir = "foo")),
+    "is not a valid argument"
+  )
+})
+
+test_that("submit_model(.mode) inherits option", {
+  other_mode <- switch(default_mode,
+    sge = "local",
+    "sge"
+  )
+  withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
     expect_identical(
-      res[[PROC_CALL]],
-      as.character(
-        glue(
-          "{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel",
-          "--config={temp_config}",
-          .sep = " "
-        )
-      )
-    )
-  })
-
-  test_that("submit_model() throws an error if passed `output_dir` bbi arg", {
-    expect_error(
-      submit_model(MOD1, .bbi_args = list(output_dir = "foo")),
-      "is not a valid argument"
-    )
-  })
-
-  test_that("submit_model(.mode) inherits option", {
-    other_mode <- switch(default_mode, sge = "local", "sge")
-    withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
-      expect_identical(
-        submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
-        as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
-      )
-    })
-  })
-
-  test_that("submit_model(.mode) errors when NULL", {
-    withr::with_options(list(bbr.bbi_exe_mode = NULL), {
-      expect_error(
-        submit_model(MOD1, .dry_run = TRUE),
-        regexp = "Nothing was passed.+mode"
-      )
-    })
-  })
-
-  test_that("submit_model(.mode) errors when invalid", {
-    expect_error(
-      submit_model(MOD1, .dry_run = TRUE, .mode = "naw"),
-      regexp = "Invalid value passed.+mode"
+      submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
+      as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
     )
   })
 })
 
+test_that("submit_model(.mode) errors when NULL", {
+  withr::with_options(list(bbr.bbi_exe_mode = NULL), {
+    expect_error(
+      submit_model(MOD1, .dry_run = TRUE),
+      regexp = "Nothing was passed.+mode"
+    )
+  })
+})
+
+test_that("submit_model(.mode) errors when invalid", {
+  expect_error(
+    submit_model(MOD1, .dry_run = TRUE, .mode = "naw"),
+    regexp = "Invalid value passed.+mode"
+  )
+})

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -18,7 +18,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
   cmd_prefix <- paste("cd", model_dir, ";",
                       read_bbi_path(), "nonmem", "run",
                       default_mode)
-  test_that("submit_model(.dry_run=TRUE) returns correct command string [BBR-SBMT-001]",
+  test_that("submit_model(.dry_run=TRUE) returns correct command string",
             {
 
               # correctly parsing yaml
@@ -46,7 +46,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_model(.dry_run=TRUE) with bbi_nonmem_model object parses correctly [BBR-SBMT-002]",
+  test_that("submit_model(.dry_run=TRUE) with bbi_nonmem_model object parses correctly",
             {
               # correctly parsing yaml
               expect_identical(
@@ -61,7 +61,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_model() creates correct call for non-NULL .config_path [BBR-SBMT-003]", {
+  test_that("submit_model() creates correct call for non-NULL .config_path", {
 
     temp_config <- tempfile(fileext = ".yaml")
     readr::write_file("foo", temp_config)
@@ -81,14 +81,14 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("submit_model() throws an error if passed `output_dir` bbi arg [BBR-SBMT-004]", {
+  test_that("submit_model() throws an error if passed `output_dir` bbi arg", {
     expect_error(
       submit_model(MOD1, .bbi_args = list(output_dir = "foo")),
       "is not a valid argument"
     )
   })
 
-  test_that("submit_model(.mode) inherits option [BBR-SBMT-005]", {
+  test_that("submit_model(.mode) inherits option", {
     other_mode <- switch(default_mode, sge = "local", "sge")
     withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
       expect_identical(
@@ -98,7 +98,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     })
   })
 
-  test_that("submit_model(.mode) errors when NULL [BBR-SBMT-006]", {
+  test_that("submit_model(.mode) errors when NULL", {
     withr::with_options(list(bbr.bbi_exe_mode = NULL), {
       expect_error(
         submit_model(MOD1, .dry_run = TRUE),
@@ -107,7 +107,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     })
   })
 
-  test_that("submit_model(.mode) errors when invalid [BBR-SBMT-007]", {
+  test_that("submit_model(.mode) errors when invalid", {
     expect_error(
       submit_model(MOD1, .dry_run = TRUE, .mode = "naw"),
       regexp = "Invalid value passed.+mode"

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -26,12 +26,6 @@ test_that("submit_model(.dry_run=TRUE) returns correct command string", {
     as.character(glue("{cmd_prefix} {default_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
   )
 
-  # switch to local mode
-  expect_identical(
-    submit_model(MOD1, .mode = "local", .dry_run = TRUE)[[PROC_CALL]],
-    as.character(glue("{cmd_prefix} local {mod_ctl_path} --overwrite --threads=4 --parallel"))
-  )
-
   # over-riding yaml arg with passed args
   expect_identical(
     submit_model(MOD1,
@@ -83,6 +77,14 @@ test_that("submit_model() throws an error if passed `output_dir` bbi arg", {
   expect_error(
     submit_model(MOD1, .bbi_args = list(output_dir = "foo")),
     "is not a valid argument"
+  )
+})
+
+test_that("submit_model() .mode argument overrides bbr.bbi_exe_mode default", {
+  other_mode <- if (identical(default_mode, "local")) "slurm" else "local"
+  expect_identical(
+    submit_model(MOD1, .mode = other_mode, .dry_run = TRUE)[[PROC_CALL]],
+    as.character(glue("{cmd_prefix} {other_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
   )
 })
 

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -87,10 +87,7 @@ test_that("submit_model() throws an error if passed `output_dir` bbi arg", {
 })
 
 test_that("submit_model(.mode) inherits option", {
-  other_mode <- switch(default_mode,
-    sge = "local",
-    "sge"
-  )
+  other_mode <- if (identical(default_mode, "local")) "slurm" else "local"
   withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
     expect_identical(
       submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -12,11 +12,7 @@ readr::write_file("created_by: test-submit-model", file.path(model_dir, "bbi.yam
 on.exit(fs::file_delete(file.path(model_dir, "bbi.yaml")))
 
 default_mode <- getOption("bbr.bbi_exe_mode")
-cmd_prefix <- paste(
-  "cd", model_dir, ";",
-  read_bbi_path(), "nonmem", "run",
-  default_mode
-)
+cmd_prefix <- paste("cd", model_dir, ";", read_bbi_path(), "nonmem", "run")
 
 withr::local_options(list(bbr.bbi_exe_path = read_bbi_path()))
 
@@ -24,13 +20,13 @@ test_that("submit_model(.dry_run=TRUE) returns correct command string", {
   # correctly parsing yaml
   expect_identical(
     submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
-    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
+    as.character(glue("{cmd_prefix} {default_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
   )
 
   # switch to local mode
   expect_identical(
     submit_model(MOD1, .mode = "local", .dry_run = TRUE)[[PROC_CALL]],
-    as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run local {mod_ctl_path} --overwrite --threads=4 --parallel"))
+    as.character(glue("{cmd_prefix} local {mod_ctl_path} --overwrite --threads=4 --parallel"))
   )
 
   # over-riding yaml arg with passed args
@@ -43,7 +39,7 @@ test_that("submit_model(.dry_run=TRUE) returns correct command string", {
       ),
       .dry_run = TRUE
     )[[PROC_CALL]],
-    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --json --nm_version=nm74 --parallel"))
+    as.character(glue("{cmd_prefix} {default_mode} {mod_ctl_path} --overwrite --threads=2 --json --nm_version=nm74 --parallel"))
   )
 })
 
@@ -51,13 +47,13 @@ test_that("submit_model(.dry_run=TRUE) with bbi_nonmem_model object parses corre
   # correctly parsing yaml
   expect_identical(
     submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
-    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel"))
+    as.character(glue("{cmd_prefix} {default_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
   )
 
   # over-riding yaml arg with passed arg
   expect_identical(
     submit_model(MOD1, list(threads = 2), .dry_run = TRUE)[[PROC_CALL]],
-    as.character(glue("{cmd_prefix} {mod_ctl_path} --overwrite --threads=2 --parallel"))
+    as.character(glue("{cmd_prefix} {default_mode} {mod_ctl_path} --overwrite --threads=2 --parallel"))
   )
 })
 
@@ -72,7 +68,7 @@ test_that("submit_model() creates correct call for non-NULL .config_path", {
     res[[PROC_CALL]],
     as.character(
       glue(
-        "{cmd_prefix} {mod_ctl_path} --overwrite --threads=4 --parallel",
+        "{cmd_prefix} {default_mode} {mod_ctl_path} --overwrite --threads=4 --parallel",
         "--config={temp_config}",
         .sep = " "
       )
@@ -95,7 +91,7 @@ test_that("submit_model(.mode) inherits option", {
   withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
     expect_identical(
       submit_model(MOD1, .dry_run = TRUE)[[PROC_CALL]],
-      as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
+      as.character(glue("{cmd_prefix} {other_mode} {mod_ctl_path} --overwrite --threads=4 --parallel"))
     )
   })
 })

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -1,4 +1,4 @@
-context("submit_models(.dry_run=T)")
+context("submit_models(.dry_run=TRUE)")
 
 #####################################
 # testing multiple model submission
@@ -21,7 +21,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
                       read_bbi_path(), "nonmem", "run",
                       default_mode)
 
-  test_that("submit_models(.dry_run=T) with list input simple [BBR-SBMT-008]",
+  test_that("submit_models(.dry_run=TRUE) with list input simple [BBR-SBMT-008]",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2)
@@ -31,7 +31,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               .mods <- list(MOD1, mod2, mod3)
 
               # submit models
-              proc_list <- submit_models(.mods, .dry_run = T)
+              proc_list <- submit_models(.mods, .dry_run = TRUE)
               expect_true(all(purrr::map_lgl(proc_list, function(.proc) { "bbi_process" %in% class(.proc) })))
 
               # check that there is only one distinct arg set
@@ -44,7 +44,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models(.dry_run=T) with list input, 2 arg sets [BBR-SBMT-010]",
+  test_that("submit_models(.dry_run=TRUE) with list input, 2 arg sets [BBR-SBMT-010]",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2) %>% add_bbi_args(list(threads = 3))
@@ -54,7 +54,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               .mods <- list(MOD1, mod2, mod3)
 
               # submit and test that passed .bbi_args override args in object
-              proc_list <- submit_models(.mods, .dry_run = T, .bbi_args = list(threads = 1))
+              proc_list <- submit_models(.mods, .dry_run = TRUE, .bbi_args = list(threads = 1))
               expect_true(all(purrr::map_lgl(proc_list, function(.proc) { "bbi_process" %in% class(.proc) })))
 
               # check that there are two distinct arg sets
@@ -97,7 +97,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(length(proc_list), 2L)
   })
 
-  test_that("submit_models(.dry_run=T) errors with bad input [BBR-SBMT-012]",
+  test_that("submit_models(.dry_run=TRUE) errors with bad input [BBR-SBMT-012]",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2)
@@ -109,7 +109,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               .mods <- list(MOD1, mod2, mod3, fake)
 
               expect_error(
-                submit_models(.mods, .dry_run = T),
+                submit_models(.mods, .dry_run = TRUE),
                 regexp = "must contain only model objects"
               )
 
@@ -119,7 +119,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               .mods <- list(MOD1, mod2, mod3, fake)
 
               expect_error(
-                submit_models(.mods, .dry_run = T),
+                submit_models(.mods, .dry_run = TRUE),
                 regexp = "must contain all the same type of models"
               )
             })
@@ -190,7 +190,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     other_mode <- switch(default_mode, sge = "local", "sge")
     withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
       expect_identical(
-        submit_models(list(MOD1), .dry_run = T)[[1]][[PROC_CALL]],
+        submit_models(list(MOD1), .dry_run = TRUE)[[1]][[PROC_CALL]],
         as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {ABS_CTL_PATH} --overwrite --parallel --threads=4"))
       )
     })

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -4,7 +4,10 @@ context("submit_models(.dry_run=TRUE)")
 # testing multiple model submission
 #####################################
 
-withr::local_options(list(bbr.bbi_exe_path = read_bbi_path()))
+withr::local_options(list(
+  bbr.bbi_exe_path = read_bbi_path(),
+  bbr.DEV_skip_system_mode_checks = TRUE
+))
 
 # create fake bbi.yaml
 readr::write_file("created_by: test-submit-models", file.path(MODEL_DIR, "bbi.yaml"))

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -17,11 +17,7 @@ mod_ctl_path <- purrr::map_chr(
 )
 
 default_mode <- getOption("bbr.bbi_exe_mode")
-cmd_prefix <- paste(
-  "cd", model_dir, ";",
-  read_bbi_path(), "nonmem", "run",
-  default_mode
-)
+cmd_prefix <- paste("cd", model_dir, ";", read_bbi_path(), "nonmem", "run")
 
 test_that("submit_models(.dry_run=TRUE) with list input simple", {
   # copy to two new models
@@ -43,7 +39,7 @@ test_that("submit_models(.dry_run=TRUE) with list input simple", {
   # check call
   expect_identical(
     proc_list[[1]][[PROC_CALL]],
-    as.character(glue("{cmd_prefix} {paste(mod_ctl_path, collapse = ' ')} --overwrite --parallel --threads=4"))
+    as.character(glue("{cmd_prefix} {default_mode} {paste(mod_ctl_path, collapse = ' ')} --overwrite --parallel --threads=4"))
   )
 })
 
@@ -69,14 +65,14 @@ test_that("submit_models(.dry_run=TRUE) with list input, 2 arg sets", {
     proc_list[[1]][[PROC_CALL]],
     as.character(
       glue(
-        "{cmd_prefix} {mod_ctl_path[1]} {mod_ctl_path[2]} --overwrite --threads=1"
+        "{cmd_prefix} {default_mode} {mod_ctl_path[1]} {mod_ctl_path[2]} --overwrite --threads=1"
       )
     )
   )
   expect_identical(
     proc_list[[2]][[PROC_CALL]],
     as.character(
-      glue("{cmd_prefix} {mod_ctl_path[3]} --clean_lvl=2 --overwrite --threads=1")
+      glue("{cmd_prefix} {default_mode} {mod_ctl_path[3]} --clean_lvl=2 --overwrite --threads=1")
     )
   )
 })
@@ -144,7 +140,7 @@ test_that("submit_models() works with non-NULL .config_path", {
     res[[1L]][[PROC_CALL]],
     as.character(
       glue(
-        "{cmd_prefix} {mod_ctl_path[[1L]]} --overwrite --parallel --threads=4",
+        "{cmd_prefix} {default_mode} {mod_ctl_path[[1L]]} --overwrite --parallel --threads=4",
         "--config={temp_config}",
         .sep = " "
       )
@@ -163,7 +159,7 @@ test_that("submit_models() works if .bbi_args is empty", {
   expect_identical(
     res[[1L]][[PROC_CALL]],
     as.character(
-      glue("{cmd_prefix} {mod_ctl_path[[1L]]} --parallel")
+      glue("{cmd_prefix} {default_mode} {mod_ctl_path[[1L]]} --parallel")
     )
   )
 
@@ -198,7 +194,7 @@ test_that("submit_models(.mode) inherits option", {
   withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
     expect_identical(
       submit_models(list(MOD1), .dry_run = TRUE)[[1]][[PROC_CALL]],
-      as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {ABS_CTL_PATH} --overwrite --parallel --threads=4"))
+      as.character(glue("{cmd_prefix} {other_mode} {ABS_CTL_PATH} --overwrite --parallel --threads=4"))
     )
   })
 })

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -190,10 +190,7 @@ test_that("submit_models() works if .bbi_args is empty", {
 })
 
 test_that("submit_models(.mode) inherits option", {
-  other_mode <- switch(default_mode,
-    sge = "local",
-    "sge"
-  )
+  other_mode <- if (identical(default_mode, "local")) "slurm" else "local"
   withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
     expect_identical(
       submit_models(list(MOD1), .dry_run = TRUE)[[1]][[PROC_CALL]],

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -4,196 +4,201 @@ context("submit_models(.dry_run=TRUE)")
 # testing multiple model submission
 #####################################
 
-withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
+withr::local_options(list(bbr.bbi_exe_path = read_bbi_path()))
+
+# create fake bbi.yaml
+readr::write_file("created_by: test-submit-models", file.path(MODEL_DIR, "bbi.yaml"))
+on.exit(fs::file_delete(file.path(MODEL_DIR, "bbi.yaml")))
+
+model_dir <- ABS_MODEL_DIR
+mod_ctl_path <- purrr::map_chr(
+  as.character(1:3),
+  ~ file.path(model_dir, fs::path_ext_set(., "ctl"))
+)
+
+default_mode <- getOption("bbr.bbi_exe_mode")
+cmd_prefix <- paste(
+  "cd", model_dir, ";",
+  read_bbi_path(), "nonmem", "run",
+  default_mode
+)
+
+test_that("submit_models(.dry_run=TRUE) with list input simple", {
+  # copy to two new models
+  mod2 <- copy_model_from(MOD1, 2)
+  mod3 <- copy_model_from(MOD1, 3)
+  on.exit(cleanup())
+
+  .mods <- list(MOD1, mod2, mod3)
+
+  # submit models
+  proc_list <- submit_models(.mods, .dry_run = TRUE)
+  expect_true(all(purrr::map_lgl(proc_list, function(.proc) {
+    "bbi_process" %in% class(.proc)
+  })))
+
+  # check that there is only one distinct arg set
+  expect_equal(length(proc_list), 1)
+
+  # check call
+  expect_identical(
+    proc_list[[1]][[PROC_CALL]],
+    as.character(glue("{cmd_prefix} {paste(mod_ctl_path, collapse = ' ')} --overwrite --parallel --threads=4"))
+  )
+})
+
+test_that("submit_models(.dry_run=TRUE) with list input, 2 arg sets", {
+  # copy to two new models
+  mod2 <- copy_model_from(MOD1, 2) %>% add_bbi_args(list(threads = 3))
+  mod3 <- copy_model_from(MOD1, 3) %>% add_bbi_args(list(clean_lvl = 2))
+  on.exit(cleanup())
+
+  .mods <- list(MOD1, mod2, mod3)
+
+  # submit and test that passed .bbi_args override args in object
+  proc_list <- submit_models(.mods, .dry_run = TRUE, .bbi_args = list(threads = 1))
+  expect_true(all(purrr::map_lgl(proc_list, function(.proc) {
+    "bbi_process" %in% class(.proc)
+  })))
+
+  # check that there are two distinct arg sets
+  expect_equal(length(proc_list), 2)
+
+  # check each call
+  expect_identical(
+    proc_list[[1]][[PROC_CALL]],
+    as.character(
+      glue(
+        "{cmd_prefix} {mod_ctl_path[1]} {mod_ctl_path[2]} --overwrite --threads=1"
+      )
+    )
+  )
+  expect_identical(
+    proc_list[[2]][[PROC_CALL]],
+    as.character(
+      glue("{cmd_prefix} {mod_ctl_path[3]} --clean_lvl=2 --overwrite --threads=1")
+    )
+  )
+})
+
+test_that("submit_models() works for models in different directories", {
+  new_dir <- file.path(ABS_MODEL_DIR, "level2")
+  fs::dir_create(new_dir)
 
   # create fake bbi.yaml
-  readr::write_file("created_by: test-submit-models", file.path(MODEL_DIR, "bbi.yaml"))
-  on.exit({ fs::file_delete(file.path(MODEL_DIR, "bbi.yaml")) })
+  readr::write_file("created_by: test-submit-models", file.path(new_dir, "bbi.yaml"))
+  on.exit(fs::file_delete(file.path(new_dir, "bbi.yaml")))
+  on.exit(cleanup())
 
-  model_dir <- ABS_MODEL_DIR
-  mod_ctl_path <- purrr::map_chr(
-    as.character(1:3),
-    ~ file.path(model_dir, fs::path_ext_set(., "ctl"))
+  # TODO: use test helper functions, e.g., create_all_models(), once the
+  # model_directory option is deprecated
+  mod2 <- copy_model_from(
+    MOD1,
+    file.path(new_dir, MOD_ID),
+    "created by test-submit-models.R"
+  )
+  proc_list <- submit_models(list(MOD1, mod2), .dry_run = TRUE)
+
+  expect_equal(length(proc_list), 2L)
+})
+
+test_that("submit_models(.dry_run=TRUE) errors with bad input", {
+  # copy to two new models
+  mod2 <- copy_model_from(MOD1, 2)
+  mod3 <- copy_model_from(MOD1, 3)
+  on.exit(cleanup())
+
+  # testing when one isn't a model
+  fake <- list(naw = 1)
+  .mods <- list(MOD1, mod2, mod3, fake)
+
+  expect_error(
+    submit_models(.mods, .dry_run = TRUE),
+    regexp = "must contain only model objects"
   )
 
-  default_mode <- getOption("bbr.bbi_exe_mode")
-  cmd_prefix <- paste("cd", model_dir, ";",
-                      read_bbi_path(), "nonmem", "run",
-                      default_mode)
+  # testing two different kinds of models
+  class(fake) <- c(BBI_BASE_MODEL_CLASS, class(fake))
+  fake[[YAML_MOD_TYPE]] <- "fake"
+  .mods <- list(MOD1, mod2, mod3, fake)
 
-  test_that("submit_models(.dry_run=TRUE) with list input simple",
-            {
-              # copy to two new models
-              mod2 <- copy_model_from(MOD1, 2)
-              mod3 <- copy_model_from(MOD1, 3)
-              on.exit({ cleanup() })
+  expect_error(
+    submit_models(.mods, .dry_run = TRUE),
+    regexp = "must contain all the same type of models"
+  )
+})
 
-              .mods <- list(MOD1, mod2, mod3)
+test_that("submit_models() works with non-NULL .config_path", {
+  temp_config <- tempfile(fileext = ".yaml")
+  readr::write_file("foo", temp_config)
+  temp_config <- normalizePath(temp_config)
+  on.exit(fs::file_delete(temp_config))
 
-              # submit models
-              proc_list <- submit_models(.mods, .dry_run = TRUE)
-              expect_true(all(purrr::map_lgl(proc_list, function(.proc) { "bbi_process" %in% class(.proc) })))
+  res <- submit_models(
+    list(MOD1),
+    .config_path = temp_config,
+    .dry_run = TRUE
+  )
 
-              # check that there is only one distinct arg set
-              expect_equal(length(proc_list), 1)
-
-              # check call
-              expect_identical(
-                proc_list[[1]][[PROC_CALL]],
-                as.character(glue("{cmd_prefix} {paste(mod_ctl_path, collapse = ' ')} --overwrite --parallel --threads=4"))
-              )
-            })
-
-  test_that("submit_models(.dry_run=TRUE) with list input, 2 arg sets",
-            {
-              # copy to two new models
-              mod2 <- copy_model_from(MOD1, 2) %>% add_bbi_args(list(threads = 3))
-              mod3 <- copy_model_from(MOD1, 3) %>% add_bbi_args(list(clean_lvl = 2))
-              on.exit({ cleanup() })
-
-              .mods <- list(MOD1, mod2, mod3)
-
-              # submit and test that passed .bbi_args override args in object
-              proc_list <- submit_models(.mods, .dry_run = TRUE, .bbi_args = list(threads = 1))
-              expect_true(all(purrr::map_lgl(proc_list, function(.proc) { "bbi_process" %in% class(.proc) })))
-
-              # check that there are two distinct arg sets
-              expect_equal(length(proc_list), 2)
-
-              # check each call
-              expect_identical(
-                proc_list[[1]][[PROC_CALL]],
-                as.character(
-                  glue(
-                    "{cmd_prefix} {mod_ctl_path[1]} {mod_ctl_path[2]} --overwrite --threads=1"
-                  )
-                )
-              )
-              expect_identical(
-                proc_list[[2]][[PROC_CALL]],
-                as.character(
-                  glue("{cmd_prefix} {mod_ctl_path[3]} --clean_lvl=2 --overwrite --threads=1"))
-              )
-            })
-
-  test_that("submit_models() works for models in different directories", {
-    new_dir <- file.path(ABS_MODEL_DIR, "level2")
-    fs::dir_create(new_dir)
-
-    # create fake bbi.yaml
-    readr::write_file("created_by: test-submit-models", file.path(new_dir, "bbi.yaml"))
-    on.exit({ fs::file_delete(file.path(new_dir, "bbi.yaml")) })
-    on.exit(cleanup())
-
-    # TODO: use test helper functions, e.g., create_all_models(), once the
-    # model_directory option is deprecated
-    mod2 <- copy_model_from(
-      MOD1,
-      file.path(new_dir, MOD_ID),
-      "created by test-submit-models.R"
+  expect_identical(
+    res[[1L]][[PROC_CALL]],
+    as.character(
+      glue(
+        "{cmd_prefix} {mod_ctl_path[[1L]]} --overwrite --parallel --threads=4",
+        "--config={temp_config}",
+        .sep = " "
+      )
     )
-    proc_list <- submit_models(list(MOD1, mod2), .dry_run = TRUE)
+  )
+})
 
-    expect_equal(length(proc_list), 2L)
-  })
+test_that("submit_models() works if .bbi_args is empty", {
+  # set existing arguments to NULL via `.bbi_args`
+  res <- submit_models(
+    list(MOD1),
+    .bbi_args = list(overwrite = NULL, threads = NULL, parallel = TRUE),
+    .dry_run = TRUE
+  )
 
-  test_that("submit_models(.dry_run=TRUE) errors with bad input",
-            {
-              # copy to two new models
-              mod2 <- copy_model_from(MOD1, 2)
-              mod3 <- copy_model_from(MOD1, 3)
-              on.exit({ cleanup() })
-
-              # testing when one isn't a model
-              fake <- list(naw = 1)
-              .mods <- list(MOD1, mod2, mod3, fake)
-
-              expect_error(
-                submit_models(.mods, .dry_run = TRUE),
-                regexp = "must contain only model objects"
-              )
-
-              # testing two different kinds of models
-              class(fake) <- c(BBI_BASE_MODEL_CLASS, class(fake))
-              fake[[YAML_MOD_TYPE]] <- "fake"
-              .mods <- list(MOD1, mod2, mod3, fake)
-
-              expect_error(
-                submit_models(.mods, .dry_run = TRUE),
-                regexp = "must contain all the same type of models"
-              )
-            })
-
-  test_that("submit_models() works with non-NULL .config_path", {
-    temp_config <- tempfile(fileext = ".yaml")
-    readr::write_file("foo", temp_config)
-    temp_config <- normalizePath(temp_config)
-    on.exit(fs::file_delete(temp_config))
-
-    res <- submit_models(
-      list(MOD1),
-      .config_path = temp_config,
-      .dry_run = TRUE
+  expect_identical(
+    res[[1L]][[PROC_CALL]],
+    as.character(
+      glue("{cmd_prefix} {mod_ctl_path[[1L]]} --parallel")
     )
+  )
 
+  # now the case where the YAML file does not contain any CLI arguments
+  temp_mod_path <- create_temp_model()
+  mod <- read_model(temp_mod_path)
+  mod <- replace_all_bbi_args(mod, NULL)
+
+  # create fake bbi.yaml
+  readr::write_file("created_by: test-submit-models", file.path(dirname(temp_mod_path), "bbi.yaml"))
+  on.exit(fs::file_delete(file.path(dirname(temp_mod_path), "bbi.yaml")))
+
+  res <- submit_models(list(mod), .dry_run = TRUE)
+
+  expect_identical(
+    res[[1L]][[PROC_CALL]],
+    as.character(
+      glue(
+        "cd {dirname(temp_mod_path)} ;",
+        "{read_bbi_path()} nonmem run {default_mode} {fs::path_ext_set(temp_mod_path, 'ctl')}",
+        .sep = " "
+      )
+    )
+  )
+})
+
+test_that("submit_models(.mode) inherits option", {
+  other_mode <- switch(default_mode,
+    sge = "local",
+    "sge"
+  )
+  withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
     expect_identical(
-      res[[1L]][[PROC_CALL]],
-      as.character(
-        glue(
-          "{cmd_prefix} {mod_ctl_path[[1L]]} --overwrite --parallel --threads=4",
-          "--config={temp_config}",
-          .sep = " "
-        )
-      )
+      submit_models(list(MOD1), .dry_run = TRUE)[[1]][[PROC_CALL]],
+      as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {ABS_CTL_PATH} --overwrite --parallel --threads=4"))
     )
   })
-
-  test_that("submit_models() works if .bbi_args is empty", {
-    # set existing arguments to NULL via `.bbi_args`
-    res <- submit_models(
-      list(MOD1),
-      .bbi_args = list(overwrite = NULL, threads = NULL, parallel = TRUE),
-      .dry_run = TRUE
-    )
-
-    expect_identical(
-      res[[1L]][[PROC_CALL]],
-      as.character(
-        glue("{cmd_prefix} {mod_ctl_path[[1L]]} --parallel")
-      )
-    )
-
-    # now the case where the YAML file does not contain any CLI arguments
-    temp_mod_path <- create_temp_model()
-    mod <- read_model(temp_mod_path)
-    mod <- replace_all_bbi_args(mod, NULL)
-
-    # create fake bbi.yaml
-    readr::write_file("created_by: test-submit-models", file.path(dirname(temp_mod_path), "bbi.yaml"))
-    on.exit({ fs::file_delete(file.path(dirname(temp_mod_path), "bbi.yaml")) })
-
-    res <- submit_models(list(mod), .dry_run = TRUE)
-
-    expect_identical(
-      res[[1L]][[PROC_CALL]],
-      as.character(
-        glue(
-          "cd {dirname(temp_mod_path)} ;",
-          "{read_bbi_path()} nonmem run {default_mode} {fs::path_ext_set(temp_mod_path, 'ctl')}",
-          .sep = " "
-        )
-      )
-    )
-  })
-
-  test_that("submit_models(.mode) inherits option", {
-    other_mode <- switch(default_mode, sge = "local", "sge")
-    withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
-      expect_identical(
-        submit_models(list(MOD1), .dry_run = TRUE)[[1]][[PROC_CALL]],
-        as.character(glue("cd {model_dir} ; {read_bbi_path()} nonmem run {other_mode} {ABS_CTL_PATH} --overwrite --parallel --threads=4"))
-      )
-    })
-  })
-}) # closing withr::with_options
-
+})

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -21,7 +21,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
                       read_bbi_path(), "nonmem", "run",
                       default_mode)
 
-  test_that("submit_models(.dry_run=TRUE) with list input simple [BBR-SBMT-008]",
+  test_that("submit_models(.dry_run=TRUE) with list input simple",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2)
@@ -44,7 +44,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models(.dry_run=TRUE) with list input, 2 arg sets [BBR-SBMT-010]",
+  test_that("submit_models(.dry_run=TRUE) with list input, 2 arg sets",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2) %>% add_bbi_args(list(threads = 3))
@@ -76,7 +76,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models() works for models in different directories [BBR-SBMT-011]", {
+  test_that("submit_models() works for models in different directories", {
     new_dir <- file.path(ABS_MODEL_DIR, "level2")
     fs::dir_create(new_dir)
 
@@ -97,7 +97,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_equal(length(proc_list), 2L)
   })
 
-  test_that("submit_models(.dry_run=TRUE) errors with bad input [BBR-SBMT-012]",
+  test_that("submit_models(.dry_run=TRUE) errors with bad input",
             {
               # copy to two new models
               mod2 <- copy_model_from(MOD1, 2)
@@ -124,7 +124,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
               )
             })
 
-  test_that("submit_models() works with non-NULL .config_path [BBR-SBMT-013]", {
+  test_that("submit_models() works with non-NULL .config_path", {
     temp_config <- tempfile(fileext = ".yaml")
     readr::write_file("foo", temp_config)
     temp_config <- normalizePath(temp_config)
@@ -148,7 +148,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("submit_models() works if .bbi_args is empty [BBR-SBMT-014]", {
+  test_that("submit_models() works if .bbi_args is empty", {
     # set existing arguments to NULL via `.bbi_args`
     res <- submit_models(
       list(MOD1),
@@ -186,7 +186,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     )
   })
 
-  test_that("submit_models(.mode) inherits option [BBR-SBMT-015]", {
+  test_that("submit_models(.mode) inherits option", {
     other_mode <- switch(default_mode, sge = "local", "sge")
     withr::with_options(list(bbr.bbi_exe_mode = other_mode), {
       expect_identical(

--- a/tests/testthat/test-submit-models.R
+++ b/tests/testthat/test-submit-models.R
@@ -139,7 +139,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_identical(
       res[[1L]][[PROC_CALL]],
       as.character(
-        glue::glue(
+        glue(
           "{cmd_prefix} {mod_ctl_path[[1L]]} --overwrite --parallel --threads=4",
           "--config={temp_config}",
           .sep = " "
@@ -159,7 +159,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_identical(
       res[[1L]][[PROC_CALL]],
       as.character(
-        glue::glue("{cmd_prefix} {mod_ctl_path[[1L]]} --parallel")
+        glue("{cmd_prefix} {mod_ctl_path[[1L]]} --parallel")
       )
     )
 
@@ -177,7 +177,7 @@ withr::with_options(list(bbr.bbi_exe_path = read_bbi_path()), {
     expect_identical(
       res[[1L]][[PROC_CALL]],
       as.character(
-        glue::glue(
+        glue(
           "cd {dirname(temp_mod_path)} ;",
           "{read_bbi_path()} nonmem run {default_mode} {fs::path_ext_set(temp_mod_path, 'ctl')}",
           .sep = " "


### PR DESCRIPTION
This is the sister PR to metrumresearchgroup/bbi#338 and adds support for calling `bbi nonmem run slurm` by passing `.mode = "slurm"` to  `submit_model`.

Most of the commits in this series are minor cleanup of the tests that check dry-run calls to `submit_model`.  The seventh commit makes the main change, which boils down to registering the new mode and adjusting the `check_mode_argument` helper.

---

Reminder for testing: by default, bbr will fail if a developmental version of bbi is used.  You can prevent that by setting the `bbr.DEV_no_min_version` option to `TRUE`.
