### PR TITLE
update IGNORE=C to work like IGNORE=@

### DIFF
--- a/R/filter-nm-data.R
+++ b/R/filter-nm-data.R
@@ -203,9 +203,9 @@ translate_nm_expr <- function(
       }else if(grepl('^[a-zA-Z]$', expr)){
         # This is for `IGNORE=C` columns. Meaning ignore rows if the _first_ column
         # contains 'C' (this form always points to the _first_ column)
-        # - the above regex looks for characters of length>=1, and no symbols
-        r_expr <- paste0(data_cols[1], "!=", "'", expr, "'")
-        add_na_filter(r_expr) %>% stats::setNames(r_expr)
+        # - the above regex looks for characters of length=1, and no symbols
+        paste0("!grepl('^", expr, "', ", data_cols[1], ")") %>%
+          stats::setNames(expr)
       }else{
         # Invert list form expressions
         r_expr <- invert_operator(expr)


### PR DESCRIPTION
Proposing that when we encounter `IGNORE=C`, we _only_ look for that character in column 1.  

From NM-help, `$DATA`

```
 IGNORE=c1

      Specifies that any data record having the character c1 in  column
      1  should be ignored, i.e., these records are not included in the
      NONMEM data set.  This allows comment records to be  included  in
      the  NM-TRAN  data set.  In general, records having the character
      c1 in column 1 will be called "comment records".
      Also permitted: IGNORE='c' or IGNORE="c",  where  c  may  be  any
      character  except  space.   IGNORE=# is the default.  That is, in
      the absence of IGNORE option, any record whose first character is
      # is treated as a comment record.
```