### PR TITLE
update ubuntu-20.04 jobs to ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
             bbi_version: v3.0.2
             mpn: 2023-01-25
             cran_override: 'https://mpn.metworx.com/snapshots/stable/2023-01-25'
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2023-01-25'
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-01-25'
     env:
       R_KEEP_PKG_SOURCE: yes
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,14 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.2.3
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.3.1
           - os: ubuntu-latest
             r: release
           - label: oldest
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             r: 4.0.5
             bbi_version: v3.0.2
             mpn: 2023-01-25


### PR DESCRIPTION
update ubuntu-20.04 jobs to ubuntu-22.04
- The ubuntu-20.04 image is scheduled to be retired on 2025-04-01