### PR TITLE
submit_model: resolve symlinks when checking for Slurm's qsub shim

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -371,7 +371,7 @@ check_mode_argument <- function(.mode) {
   }
 
   if (identical(.mode, "sge")) {
-    qsub <- unname(Sys.which("qsub"))
+    qsub <- normalizePath(unname(Sys.which("qsub")), mustWork = FALSE)
     if (identical(qsub, "")) {
       stop(".mode='sge' but qsub is not available on system")
     }


### PR DESCRIPTION
Adapt check for Slurm's qsub shim for a Metworx-side change (more details in commit message).

Summary of testing:

 * verified that guards aborts under `.mode = "sge"` on a Metworx 25-02.00.00 workflow with **Slurm**

 * verified successful run under `.mode = "slurm"` on a Metworx 25-02.00.00 workflow with **Slurm**

 * verified successful run under `.mode = "sge"` on a Metworx 25-02.00.00 workflow with **SGE**

 * `R CMD check` passes on a Metworx 25-02.00.00 workflow with **Slurm**

 * `R CMD check` passes on a Metworx 25-02.00.00 workflow with **SGE**
