### PR TITLE
Prepare 1.14.0 release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         config:
           - os: ubuntu-22.04
-            r: 4.2.3
+            r: 4.3.3
           - os: ubuntu-22.04
-            r: 4.3.1
+            r: 4.4.2
           - os: ubuntu-latest
             r: release
           - label: oldest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr
 Title: R package for bbi
-Version: 1.13.0
+Version: 1.14.0
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# bbr 1.14.0
+
+## New features and changes
+
+- `summary_log()` and `add_summary()` now report the Akaike information
+  criterion (as the "aic" column) and Bayesian information criterion (as the
+  "bic" column). (#743)
+
+- The new function `add_dofv()` extends a log with the change in objection
+  function value between each row's model and a reference model. (#743)
+
+- `submit_model()` has a guard to prevent Metworx users from accidentally
+  submitting models with Slurm's `qsub` shim.  This guard has been updated for a
+  Metworx-side change. (#742)
+
+- `run_nmtran()` learned to handle a `maxlim` value of 100 for compatibility
+  with older bbi versions. (#744)
+
 # bbr 1.13.0
 
 ## New features and changes


### PR DESCRIPTION
changeset: [1.13.0...release/1.14.0](https://github.com/metrumresearchgroup/bbr/compare/1.13.0...release/1.14.0)

In addition to normal release bits, this bumps R versions for the CI jobs.

<details>
<summary>scores</summary>


```
$ git rev-parse HEAD^{tree}
1545ec2345c233b5149590c60acb1e7c6a9d73f1
```

```json
{
  "testing": {
    "check": 1,
    "coverage": 0.8394
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>
