### PR TITLE
ci: error if check emits note if running under latest R

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,6 +80,8 @@ jobs:
             ${{ env.NMREC_PKG }}
           upgrade: ${{ matrix.config.label == 'oldest' && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          error-on: ${{ matrix.config.r == 'release' && '"note"' || '"warning"' }}
       - name: Check pkgdown
         shell: Rscript {0}
         run: pkgdown::check_pkgdown()


### PR DESCRIPTION
Ideally the check jobs would run rcmdcheck with error_on="note" so that new issues would be flagged by a CI error (e.g., Rd doc issues). There hasn't been a straightforward way to do that in the context of bbr, though, because the check has two pre-existing notes (one related to the package size and another to the number of imports) [*].

With R 4.5, these size and import messages are now marked as "info" instead of a note, so make the release build error if any notes are present.

[*] The `_R_CHECK_PKG_SIZES_` and `_R_CHECK_EXCESSIVE_IMPORTS_` environment variables exist to control these checks, but the latter has no effect under `--as-cran`.