### PR TITLE
translate_nm_operator: tighten ops matching to avoid false positives

### DIFF
--- a/R/filter-nm-data.R
+++ b/R/filter-nm-data.R
@@ -83,15 +83,16 @@ get_data_filter_exprs <- function(.mod){
 #' @seealso [invert_operator()], [translate_nm_expr()]
 translate_nm_operator <- function(expr) {
   # Check for unsupported operators
-  bad_ops <- c(".OR.",".AND", ".NOT.")
-  bad_ops_pat <- paste(bad_ops, collapse = "|")
-  if(any(grepl(bad_ops_pat, expr))){
-    cli::cli_abort(
-      c(
-        "The following logical operators are not supported {.var {bad_ops}}",
-        "i" = "See NONMEM documentation for more details"
+  for (op in c(".OR.", ".AND", ".NOT.")) {
+    bad <- grep(op, expr, fixed = TRUE, value = TRUE)
+    if (length(bad)) {
+      cli::cli_abort(
+        c(
+          "Unsupported logical operator ({.var {op}}): {.val {bad}}",
+          "i" = "See NONMEM documentation for more details"
+        )
       )
-    )
+    }
   }
 
   # Equal

--- a/R/filter-nm-data.R
+++ b/R/filter-nm-data.R
@@ -69,7 +69,7 @@ get_data_filter_exprs <- function(.mod){
 }
 
 #' Function to translate `NONMEM` operators to `R` operators
-#' @param expr String. A `NONMEM` ignore/accept expression
+#' @param expr Character vector of `NONMEM` ignore/accept expressions.
 #' @note `.EQN.` and `.NEN.` are available after `NONMEM 7.3`
 #' @return A [dplyr::filter()] expression
 #'

--- a/man/translate_nm_operator.Rd
+++ b/man/translate_nm_operator.Rd
@@ -7,7 +7,7 @@
 translate_nm_operator(expr)
 }
 \arguments{
-\item{expr}{String. A \code{NONMEM} ignore/accept expression}
+\item{expr}{Character vector of \code{NONMEM} ignore/accept expressions.}
 }
 \value{
 A \code{\link[dplyr:filter]{dplyr::filter()}} expression

--- a/tests/testthat/test-filter-nm-data.R
+++ b/tests/testthat/test-filter-nm-data.R
@@ -18,6 +18,20 @@ test_that("translate_nm_operator translates NONMEM operators", {
   )
 })
 
+test_that("translate_nm_operator: unsupported operators", {
+  cases <- list(
+    "GEN=1 .AND. AGE > 60",
+    c("SEX==1", "ID.EQ.2", "WT/=70", "GEN=1 .OR. AGE > 60"),
+    "GEN=1.NOT.AGE > 60"
+  )
+  for (case in cases) {
+    expect_error(
+      translate_nm_operator(!!case),
+      "Unsupported logical operator"
+    )
+  }
+})
+
 test_that("translate_nm_expr() translates NONMEM filter expressions", {
   test_exprs <- c("SEX==1", "ID.EQ.2", "WT/=70", "AGE.NE.30", "A=1", "WT.GT.40", "B.LE.20")
 

--- a/tests/testthat/test-filter-nm-data.R
+++ b/tests/testthat/test-filter-nm-data.R
@@ -4,13 +4,18 @@ test_that("translate_nm_operator translates NONMEM operators", {
     equal = c("A.EQ.1", "A.EQN.1", "A==1", "A=1"),
     not_equal = c("B.NE.1", "B.NEN.1", "B/=1"),
     greater_than = c("C.GE.1", "C.GT.1"),
-    less_than = c("D.LE.1", "D.LT.1")
+    less_than = c("D.LE.1", "D.LT.1"),
+    or_within = "COHORT.EQ.2"
   )
 
   expect_equal(unique(translate_nm_operator(nm_r_translations$equal)), "A==1")
   expect_equal(unique(translate_nm_operator(nm_r_translations$not_equal)), "B!=1")
   expect_equal(translate_nm_operator(nm_r_translations$greater_than), c("C>=1", "C>1"))
   expect_equal(translate_nm_operator(nm_r_translations$less_than), c("D<=1", "D<1"))
+  expect_equal(
+    translate_nm_operator(nm_r_translations$or_within),
+    "COHORT==2"
+  )
 })
 
 test_that("translate_nm_expr() translates NONMEM filter expressions", {
@@ -64,7 +69,7 @@ test_that("translate_nm_expr() translates NONMEM filter expressions", {
   test_exprs_bad <- c(test_exprs, "GEN=1 .AND. AGE > 60")
   expect_error(
     translate_nm_expr(test_exprs_bad, type = 'accept'),
-    "The following logical operators are not supported"
+    "Unsupported logical operator"
   )
 })
 


### PR DESCRIPTION
Fix the false positive @toddyoder-mrg reported in gh-776 (second commit).

While in the area, correct a parameter description in the `translate_nm_operator` docs, and expand the test cases to cover all unsupported ops.

```R
translate_nm_operator("COHORT.EQ.2")
#> [1] "COHORT==2"

translate_nm_operator(c("COHORT.EQ.2", "x .OR. y"))
#> Error in `translate_nm_operator()`:
#> ! Unsupported logical operator (`.OR.`): "x .OR. y"
#> ℹ See NONMEM documentation for more details
#> Run `rlang::last_trace()` to see where the error occurred.

translate_nm_operator(c("COHORT.EQ.2", "x .AND. y", "p.AND.q"))
#> Error in `translate_nm_operator()`:
#> ! Unsupported logical operator (`.AND`): "x .AND. y" and "p.AND.q"
#> ℹ See NONMEM documentation for more details
#> Run `rlang::last_trace()` to see where the error occurred.
```

---

@toddyoder-mrg and @kylebaron If either of you have time, please review.  Otherwise I'll request a review from @barrettk when he's back next week.